### PR TITLE
v0.2.0: Perfect Retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Misleading get_email timeout message** — when `get_email` times out, the error now checks whether account/mailbox were already provided and gives context-appropriate advice instead of always saying "Provide account/mailbox".
 - **Renamed `this_week` filter to `last_7_days`** — `this_week` kept as alias for backwards compatibility. (#49)
 - **`search_fts_highlight()` bugs** — fixed missing account/mailbox/exclude_mailboxes filters, integer row indexing, and missing FTS5 retry logic.
+- **Case-sensitive mailbox filtering** — `search(mailbox="INBOX")` now matches `Inbox`, `inbox`, etc. Previously returned zero results on case mismatch. (#67)
 - **Updated patrickfreyer benchmark config** and added `rusty_apple_mail_mcp` to benchmarks.
 
 ## [0.1.7] - 2026-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.8] - Unreleased
+## [0.2.0] - Unreleased
 
-### Fixed
+### Added
+
+- **Date-range filtering for search** — new `before` and `after` parameters (YYYY-MM-DD) on `search()`. Filter results by date across all scopes including attachments. (#9)
+- **Highlighted search results** — new `highlight` parameter on `search()`. When enabled, matched terms are wrapped in `**markers**` in subject and content_snippet using FTS5 `highlight()` and `snippet()`. (#11)
+- **`get_email_links()` tool** — extracts hyperlinks from an email's HTML content. Replaces the links mode of `get_attachment()`. (#55)
+- **`get_email_attachment()` tool** — extracts a named file attachment and saves to disk. Replaces the attachment mode of `get_attachment()`. (#55)
+- **CLI wrappers** — all MCP tools now accessible as CLI commands: `search`, `read`, `emails`, `accounts`, `mailboxes`, `extract`. Output JSON to stdout. (#61)
+- **Skill generator** — `apple-mail-mcp integrate claude` generates a Claude Code skill file for CLI-based email access. (#62)
+- **`--read-only` server flag** — `apple-mail-mcp serve --read-only` (or `APPLE_MAIL_READ_ONLY=true`) prepares for v0.3.0 write operations. (#63)
+- **Dynamic Mail version detection** — auto-detects the highest `V*` directory under `~/Library/Mail/` instead of hardcoding `V10`. (#57)
+
+### Changed
+
+- **`get_attachment()` deprecated** — still registered for backwards compatibility, but delegates to `get_email_links()` or `get_email_attachment()`. Will be removed in v0.3.0.
+
+### Fixed (from v0.1.8)
 
 - **Watcher crash on file add** — `parse_emlx()` exceptions beyond `OSError`/`ValueError`/`UnicodeDecodeError` (e.g. malformed plist, missing headers) no longer kill the watcher thread. The watcher now skips unparseable files and continues processing.
 - **Attachment cache leak** — `_cleanup_old_attachments()` is now called automatically when extracting attachments, preventing unbounded disk usage from cached files.
 - **Attachment cache permissions** — cache directory is now created with `0o700` permissions to protect sensitive email attachment content.
 - **Empty search error messages** — search index errors (corrupt DB, SQLite issues) now return actionable error messages instead of empty strings. Suggests `apple-mail-mcp rebuild` when the index is broken.
 - **Misleading get_email timeout message** — when `get_email` times out, the error now checks whether account/mailbox were already provided and gives context-appropriate advice instead of always saying "Provide account/mailbox".
-
-### Changed
-
-- **Renamed `this_week` filter to `last_7_days`** — the filter returns a rolling 7-day window, not the current calendar week. `this_week` is still accepted as an alias for backwards compatibility. (#49)
-- **Updated patrickfreyer benchmark config** — `search_email_content` tool renamed to `search_emails` with new parameter names to match their latest API.
-- **Added `rusty_apple_mail_mcp` to benchmarks** — Rust-based competitor that reads Apple's Envelope Index directly (no JXA). First non-AppleScript competitor in the benchmark suite.
+- **Renamed `this_week` filter to `last_7_days`** — `this_week` kept as alias for backwards compatibility. (#49)
+- **`search_fts_highlight()` bugs** — fixed missing account/mailbox/exclude_mailboxes filters, integer row indexing, and missing FTS5 retry logic.
+- **Updated patrickfreyer benchmark config** and added `rusty_apple_mail_mcp` to benchmarks.
 
 ## [0.1.7] - 2026-03-11
 
@@ -116,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disk-based sync for index building
 - Real-time file watcher for index updates
 
-[0.1.8]: https://github.com/imdinu/apple-mail-mcp/compare/v0.1.7...HEAD
+[0.2.0]: https://github.com/imdinu/apple-mail-mcp/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/imdinu/apple-mail-mcp/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/imdinu/apple-mail-mcp/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/imdinu/apple-mail-mcp/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/imdinu/apple-mail-mcp/compare/v0.1.4...v0.1.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ The only Apple Mail MCP server with full-text email search. Reliable on large ma
 src/apple_mail_mcp/
 ├── __init__.py         # CLI entry point, exports main()
 ├── cli.py              # CLI commands (index, status, rebuild, serve)
-├── server.py           # FastMCP server with 6 MCP tools
+├── server.py           # FastMCP server with 8 MCP tools
 ├── config.py           # Environment variable configuration
 ├── builders.py         # QueryBuilder, AccountsQueryBuilder
 ├── executor.py         # run_jxa(), execute_with_core(), execute_query()
@@ -27,7 +27,7 @@ src/apple_mail_mcp/
     └── mail_core.js    # Shared JXA utilities (MailCore object)
 ```
 
-## MCP Tools (6 total)
+## MCP Tools (8 total)
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
@@ -35,8 +35,10 @@ src/apple_mail_mcp/
 | `list_mailboxes(account?)` | List mailboxes | account (optional) |
 | `get_emails(...)` | Unified listing | filter: all/unread/flagged/today/last_7_days |
 | `get_email(id)` | Full email content + attachments | message_id |
-| `search(query, ...)` | Unified search | scope: all/subject/sender/body/attachments |
-| `get_attachment(id, filename)` | Extract attachment content | message_id, filename |
+| `search(query, ...)` | Unified search | scope, before, after, highlight |
+| `get_email_links(id)` | Extract links from an email | message_id |
+| `get_email_attachment(id, filename)` | Extract attachment content | message_id, filename |
+| `get_attachment(id, filename)` | *Deprecated* — use `get_email_attachment()` | message_id, filename |
 
 ### get_emails() Filters
 
@@ -56,6 +58,8 @@ search("john@", scope="sender")            # Sender only (JXA)
 search("meeting", scope="subject")         # Subject only (JXA)
 search("deadline", scope="body")           # Body only (FTS5)
 search("pdf", scope="attachments")         # By attachment filename (SQL)
+search("invoice", after="2025-01-01")      # Date-range filtering
+search("meeting", highlight=True)          # Highlighted results
 ```
 
 ## Architecture
@@ -87,7 +91,7 @@ Startup Sync Flow:
 ### Layer Separation
 
 1. **cli.py** - CLI entry point, commands for indexing
-2. **server.py** - 6 MCP tools, uses builders and index
+2. **server.py** - 8 MCP tools, uses builders and index
 3. **builders.py** - Constructs JXA scripts from Python, type-safe
 4. **executor.py** - Runs scripts via osascript, handles JSON parsing
 5. **index/** - FTS5 search index with disk-based sync
@@ -320,12 +324,20 @@ MailCore.formatDate(date)  // ISO string or null
 ## CLI Commands
 
 ```bash
-apple-mail-mcp            # Run MCP server (default)
-apple-mail-mcp serve      # Run MCP server explicitly
-apple-mail-mcp --watch    # Run with real-time index updates
-apple-mail-mcp index      # Build search index from disk
-apple-mail-mcp status     # Show index statistics
-apple-mail-mcp rebuild    # Force rebuild index
+apple-mail-mcp              # Run MCP server (default)
+apple-mail-mcp serve        # Run MCP server explicitly
+apple-mail-mcp serve -r     # Run in read-only mode
+apple-mail-mcp --watch      # Run with real-time index updates
+apple-mail-mcp index        # Build search index from disk
+apple-mail-mcp status       # Show index statistics
+apple-mail-mcp rebuild      # Force rebuild index
+apple-mail-mcp search       # Search emails (JSON output)
+apple-mail-mcp read         # Read a single email (JSON output)
+apple-mail-mcp emails       # List emails (JSON output)
+apple-mail-mcp accounts     # List accounts (JSON output)
+apple-mail-mcp mailboxes    # List mailboxes (JSON output)
+apple-mail-mcp extract      # Extract attachment (JSON output)
+apple-mail-mcp integrate claude  # Generate a Claude Code skill file
 ```
 
 ## Testing
@@ -438,6 +450,7 @@ for (let i = 0; i < data.sender.length; i++) {
 | `APPLE_MAIL_INDEX_MAX_EMAILS` | `5000` | Max emails per mailbox |
 | `APPLE_MAIL_INDEX_STALENESS_HOURS` | `24` | Hours before refresh |
 | `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Comma-separated mailboxes to skip |
+| `APPLE_MAIL_READ_ONLY` | `false` | Disable write operations |
 
 ## Benchmarks
 
@@ -471,7 +484,7 @@ Chart PNGs are committed (they ARE the results). JSON and HTML in `benchmarks/re
 ## Known Limitations
 
 1. **macOS Only** - Requires Apple Mail and `osascript`
-2. **Mail Version** - Hardcoded to `~/Library/Mail/V10/` (macOS Ventura+)
+2. **Mail Version** - Auto-detects highest `~/Library/Mail/V*/` directory (dynamic V10+ detection)
 3. **Full Disk Access** - Required for disk-based indexing and sync
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![CI](https://github.com/imdinu/apple-mail-mcp/actions/workflows/lint.yml/badge.svg)](https://github.com/imdinu/apple-mail-mcp/actions/workflows/lint.yml)
 
-The only Apple Mail MCP server with **full-text email search**. Reliable on large mailboxes where other servers timeout — with 6 tools for reading, searching, and extracting email content.
+The only Apple Mail MCP server with **full-text email search**. Reliable on large mailboxes where other servers timeout — with 8 tools for reading, searching, and extracting email content.
 
 **[Read the docs](https://imdinu.github.io/apple-mail-mcp/)** for the full guide.
 
@@ -48,8 +48,10 @@ apple-mail-mcp index --verbose
 | `list_mailboxes(account?)` | List mailboxes |
 | `get_emails(filter?, limit?)` | Get emails — all, unread, flagged, today, last_7_days |
 | `get_email(message_id)` | Get single email with full content + attachments |
-| `search(query, scope?)` | Search — all, subject, sender, body, attachments |
-| `get_attachment(message_id, filename)` | Extract attachment to disk, or extract links |
+| `search(query, scope?, before?, after?, highlight?)` | Search — all, subject, sender, body, attachments |
+| `get_email_links(message_id)` | Extract links from an email |
+| `get_email_attachment(message_id, filename)` | Extract attachment content |
+| `get_attachment(message_id, filename)` | *Deprecated* — use `get_email_attachment()` |
 
 ## Performance
 
@@ -71,6 +73,7 @@ Tested against [6 other Apple Mail MCP servers](https://imdinu.github.io/apple-m
 | `APPLE_MAIL_INDEX_PATH` | `~/.apple-mail-mcp/index.db` | Index location |
 | `APPLE_MAIL_INDEX_MAX_EMAILS` | `5000` | Max emails indexed per mailbox |
 | `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Mailboxes to skip in search |
+| `APPLE_MAIL_READ_ONLY` | `false` | Disable write operations |
 
 ```json
 {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ Apple Mail MCP is configured via environment variables. All settings have sensib
 | `APPLE_MAIL_INDEX_MAX_EMAILS` | `5000` | Max emails per mailbox to index |
 | `APPLE_MAIL_INDEX_STALENESS_HOURS` | `24` | Hours before index is considered stale |
 | `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Comma-separated mailboxes to skip in search |
+| `APPLE_MAIL_READ_ONLY` | `false` | When `true`, disables any write operations |
 
 ### Per-Mailbox Email Limit
 
@@ -84,12 +85,35 @@ To keep the search index automatically updated:
 ## CLI Commands
 
 ```bash
-apple-mail-mcp            # Run MCP server (default)
-apple-mail-mcp serve      # Run MCP server explicitly
-apple-mail-mcp --watch    # Run with real-time index updates
-apple-mail-mcp index      # Build search index from disk
-apple-mail-mcp status     # Show index statistics
-apple-mail-mcp rebuild    # Force rebuild index
+apple-mail-mcp              # Run MCP server (default)
+apple-mail-mcp serve        # Run MCP server explicitly
+apple-mail-mcp serve -r     # Run in read-only mode
+apple-mail-mcp --watch      # Run with real-time index updates
+apple-mail-mcp index        # Build search index from disk
+apple-mail-mcp status       # Show index statistics
+apple-mail-mcp rebuild      # Force rebuild index
+apple-mail-mcp search       # Search emails (JSON output)
+apple-mail-mcp read         # Read a single email (JSON output)
+apple-mail-mcp emails       # List emails (JSON output)
+apple-mail-mcp accounts     # List accounts (JSON output)
+apple-mail-mcp mailboxes    # List mailboxes (JSON output)
+apple-mail-mcp extract      # Extract attachment (JSON output)
+apple-mail-mcp integrate claude  # Generate a Claude Code skill file
+```
+
+### Read-Only Mode
+
+Use `--read-only` (or `-r`) on the `serve` command to prevent any write operations. This can also be set via the `APPLE_MAIL_READ_ONLY` environment variable.
+
+```bash
+apple-mail-mcp serve --read-only
+```
+
+Or via environment variable:
+
+```bash
+export APPLE_MAIL_READ_ONLY=true
+apple-mail-mcp serve
 ```
 
 ## Index Location

--- a/docs/search.md
+++ b/docs/search.md
@@ -157,6 +157,35 @@ The file watcher monitors `~/Library/Mail/V10/` for:
 - Deleted `.emlx` files → remove from index
 - Moved `.emlx` files → update path in index
 
+## Date-Range Filtering
+
+Use the `before` and `after` parameters to restrict search results to a date range. Both accept dates in `YYYY-MM-DD` format.
+
+```python
+# Emails from Q1 2025
+search("invoice", after="2025-01-01", before="2025-03-31")
+
+# Emails received after a specific date
+search("shipping confirmation", after="2025-06-01")
+
+# Emails received before a specific date
+search("contract", before="2024-12-31")
+```
+
+Date filtering is applied at the SQL level when using the FTS5 index, so it does not impact search performance.
+
+## Highlighted Results
+
+Set `highlight=True` to have matching terms wrapped in highlight markers in the result snippets. This is useful for displaying search results in a UI or for quickly identifying why a result matched.
+
+```python
+search("quarterly report", highlight=True)
+# Results include highlighted snippets, e.g.:
+# "Please find the **quarterly report** attached..."
+```
+
+When highlighting is enabled, the `content_snippet` field in each result contains the matched terms wrapped in markers.
+
 ## Performance
 
 ### Search Speed

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-Apple Mail MCP provides **6 MCP tools** — a consolidated API designed for AI assistants.
+Apple Mail MCP provides **8 MCP tools** — a consolidated API designed for AI assistants.
 
 ## Overview
 
@@ -10,8 +10,10 @@ Apple Mail MCP provides **6 MCP tools** — a consolidated API designed for AI a
 | `list_mailboxes()` | List mailboxes | `account?` |
 | `get_emails()` | Get emails with filtering | `account?`, `mailbox?`, `filter?`, `limit?` |
 | `get_email()` | Get single email with content + attachments | `message_id`, `account?`, `mailbox?` |
-| `search()` | Search emails | `query`, `account?`, `mailbox?`, `scope?`, `limit?`, `exclude_mailboxes?` |
-| `get_attachment()` | Extract attachment content | `message_id`, `filename`, `account?`, `mailbox?` |
+| `search()` | Search emails | `query`, `account?`, `mailbox?`, `scope?`, `limit?`, `exclude_mailboxes?`, `before?`, `after?`, `highlight?` |
+| `get_email_links()` | Extract links from an email | `message_id`, `account?`, `mailbox?` |
+| `get_email_attachment()` | Extract attachment content | `message_id`, `filename`, `account?`, `mailbox?` |
+| `get_attachment()` | *Deprecated* — use `get_email_attachment()` | `message_id`, `filename`, `account?`, `mailbox?` |
 
 ---
 
@@ -137,6 +139,9 @@ Search emails with automatic FTS5 optimization. Uses the FTS5 index for fast sea
 | `scope` | `string?` | `all` | Search scope (see below) |
 | `limit` | `int?` | `20` | Max results |
 | `exclude_mailboxes` | `list?` | `["Drafts"]` | Mailboxes to exclude (FTS/attachment scopes only) |
+| `before` | `string?` | `None` | Only return emails before this date (YYYY-MM-DD) |
+| `after` | `string?` | `None` | Only return emails after this date (YYYY-MM-DD) |
+| `highlight` | `bool?` | `False` | Highlight matching terms in results |
 
 **Scopes:**
 
@@ -165,11 +170,38 @@ search("pdf", scope="attachments")
 
 search("deadline", limit=5)
 # Top 5 results
+
+search("invoice", after="2025-01-01", before="2025-12-31")
+# Emails from 2025 only
+
+search("meeting", highlight=True)
+# Results with matching terms highlighted
 ```
 
 ---
 
-## `get_attachment()`
+## `get_email_links()`
+
+Extract all links (URLs) from an email's body content.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `message_id` | `int` | *required* | Email ID |
+| `account` | `string?` | `None` | Account (helps disambiguate) |
+| `mailbox` | `string?` | `None` | Mailbox (helps disambiguate) |
+
+**Returns:** List of links found in the email body.
+
+```python
+get_email_links(12345)
+# → [{"url": "https://example.com/invoice", "text": "View Invoice"}, ...]
+```
+
+---
+
+## `get_email_attachment()`
 
 Extract attachment content from an email. Parses the raw `.emlx` MIME structure, so it works for all attachment types including inline images.
 
@@ -185,10 +217,19 @@ Extract attachment content from an email. Parses the raw `.emlx` MIME structure,
 **Returns:** Dictionary with `filename`, `mime_type`, `size`, and `content_base64`. If the attachment exceeds 10 MB, returns metadata only with `truncated: true`.
 
 ```python
-get_attachment(12345, "invoice.pdf")
+get_email_attachment(12345, "invoice.pdf")
 # → {"filename": "invoice.pdf", "mime_type": "application/pdf",
 #    "size": 52340, "content_base64": "JVBERi0x..."}
 ```
 
 !!! note
-    Requires the FTS5 search index. If upgrading from v0.1.2, run `apple-mail-mcp rebuild` to populate attachment metadata.
+    Requires the FTS5 search index. If upgrading from v0.1.x, run `apple-mail-mcp rebuild` to populate attachment metadata.
+
+---
+
+## `get_attachment()` *(Deprecated)*
+
+!!! warning
+    `get_attachment()` is deprecated since v0.2.0. Use `get_email_attachment()` instead. The old name still works but may be removed in a future release.
+
+Identical to `get_email_attachment()`. See above for parameters and return value.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-mail-mcp"
-version = "0.1.8"
+version = "0.2.0"
 description = "Apple Mail MCP server with full-text email search. The only one that works reliably on large mailboxes."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/imdinu/apple-mail-mcp",
     "source": "github"
   },
-  "version": "0.1.8",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-mail-mcp",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/apple_mail_mcp/cli.py
+++ b/src/apple_mail_mcp/cli.py
@@ -57,12 +57,17 @@ def _progress_bar(current: int, total: int | None, width: int = 40) -> str:
     return f"[{bar}] {pct * 100:.0f}%"
 
 
-def _run_serve(watch: bool = False) -> None:
+def _run_serve(watch: bool = False, read_only: bool = False) -> None:
     """Internal function to run the MCP server."""
     import threading
 
+    from .config import set_read_only_mode
     from .index import IndexManager
     from .server import mcp
+
+    if read_only:
+        set_read_only_mode(True)
+        print("Read-only mode enabled", file=sys.stderr)
 
     manager = IndexManager.get_instance()
 
@@ -144,6 +149,13 @@ def serve(
             help="Enable verbose output",
         ),
     ] = False,
+    read_only: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--read-only", "-r"],
+            help="Disable write operations (v0.3.0+)",
+        ),
+    ] = False,
 ) -> None:
     """
     Run the MCP server.
@@ -155,7 +167,7 @@ def serve(
     Use --watch to enable real-time index updates when emails arrive.
     Requires Full Disk Access for the terminal.
     """
-    _run_serve(watch=watch)
+    _run_serve(watch=watch, read_only=read_only)
 
 
 @app.command
@@ -376,9 +388,321 @@ def default_handler(
             help="Enable verbose output",
         ),
     ] = False,
+    read_only: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--read-only", "-r"],
+            help="Disable write operations (v0.3.0+)",
+        ),
+    ] = False,
 ) -> None:
     """Run the MCP server (default when no command specified)."""
-    _run_serve(watch=watch)
+    _run_serve(watch=watch, read_only=read_only)
+
+
+# ========== Integration Generator ==========
+
+integrate_app = cyclopts.App(
+    name="integrate",
+    help="Generate integration files for AI tools.",
+)
+app.command(integrate_app)
+
+
+_CLAUDE_SKILL = """\
+---
+name: mail
+description: Search and read Apple Mail emails via CLI
+---
+
+Use `apple-mail-mcp` CLI to access emails on this Mac.
+
+## Search emails
+
+```
+!apple-mail-mcp search "keyword" --limit 20
+```
+
+Options:
+- `--scope` / `-s`: all (default), subject, sender, body, attachments
+- `--account` / `-a`: filter to a specific email account
+- `--after`: only emails on/after this date (YYYY-MM-DD)
+- `--before`: only emails before this date (YYYY-MM-DD)
+- `--limit` / `-n`: max results (default: 20)
+- `--no-highlight`: disable **term** markers in results
+
+Examples:
+```
+!apple-mail-mcp search "quarterly report" --scope subject
+!apple-mail-mcp search "invoice" --after 2026-01-01 --before 2026-04-01
+!apple-mail-mcp search "Kim Foulds" --account Work
+```
+
+## Read full email
+
+```
+!apple-mail-mcp read <message_id>
+```
+
+Use the `id` from search results. Returns full content, attachments list, \
+and metadata.
+
+## List emails
+
+```
+!apple-mail-mcp emails --filter unread --limit 10
+```
+
+Filters: all, unread, flagged, today, last_7_days
+
+## List accounts and mailboxes
+
+```
+!apple-mail-mcp accounts
+!apple-mail-mcp mailboxes --account Work
+```
+
+## Extract attachment or links
+
+```
+!apple-mail-mcp extract <message_id> <filename>
+!apple-mail-mcp extract <message_id>  # links mode
+```
+
+## Output format
+
+All commands return JSON. Use jq for filtering:
+```
+!apple-mail-mcp search "budget" | jq '.[].subject'
+```
+"""
+
+
+@integrate_app.command
+def claude() -> None:
+    """Generate a Claude Code skill file.
+
+    Outputs markdown to stdout. Pipe to a file:
+
+        apple-mail-mcp integrate claude \\
+            > ~/.claude/skills/apple-mail.md
+    """
+    print(_CLAUDE_SKILL)
+
+
+# ========== CLI Wrappers for MCP Tools ==========
+
+
+def _run_async(coro):
+    """Run an async MCP tool function synchronously."""
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+def _print_json(data):
+    """Print data as formatted JSON to stdout."""
+    import json
+
+    print(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+@app.command(name="search")
+def cli_search(
+    query: str,
+    scope: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--scope", "-s"],
+            help="all, subject, sender, body, attachments",
+        ),
+    ] = "all",
+    account: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--account", "-a"],
+            help="Filter to specific account",
+        ),
+    ] = None,
+    mailbox: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--mailbox", "-m"],
+            help="Filter to specific mailbox",
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        cyclopts.Parameter(name=["--limit", "-n"], help="Max results"),
+    ] = 20,
+    before: Annotated[
+        str | None,
+        cyclopts.Parameter(help="Before date (YYYY-MM-DD)"),
+    ] = None,
+    after: Annotated[
+        str | None,
+        cyclopts.Parameter(help="After date (YYYY-MM-DD)"),
+    ] = None,
+    highlight: Annotated[
+        bool,
+        cyclopts.Parameter(help="Highlight matched terms"),
+    ] = True,
+) -> None:
+    """Search emails using the FTS5 index."""
+    from .server import search as _search
+
+    try:
+        result = _run_async(
+            _search(
+                query,
+                account=account,
+                mailbox=mailbox,
+                scope=scope,
+                limit=limit,
+                before=before,
+                after=after,
+                highlight=highlight,
+            )
+        )
+        _print_json(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+@app.command(name="read")
+def cli_read(
+    message_id: int,
+    account: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--account", "-a"],
+            help="Account name (speeds up lookup)",
+        ),
+    ] = None,
+    mailbox: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name=["--mailbox", "-m"],
+            help="Mailbox name (speeds up lookup)",
+        ),
+    ] = None,
+) -> None:
+    """Read a single email with full content."""
+    from .server import get_email
+
+    try:
+        result = _run_async(
+            get_email(message_id, account=account, mailbox=mailbox)
+        )
+        _print_json(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+@app.command(name="emails")
+def cli_emails(
+    account: Annotated[
+        str | None,
+        cyclopts.Parameter(name=["--account", "-a"], help="Account name"),
+    ] = None,
+    mailbox: Annotated[
+        str | None,
+        cyclopts.Parameter(name=["--mailbox", "-m"], help="Mailbox name"),
+    ] = None,
+    filter: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--filter", "-f"],
+            help="all, unread, flagged, today, last_7_days",
+        ),
+    ] = "all",
+    limit: Annotated[
+        int,
+        cyclopts.Parameter(name=["--limit", "-n"], help="Max results"),
+    ] = 50,
+) -> None:
+    """List emails from a mailbox."""
+    from .server import get_emails
+
+    try:
+        result = _run_async(
+            get_emails(account, mailbox, filter=filter, limit=limit)
+        )
+        _print_json(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+@app.command(name="accounts")
+def cli_accounts() -> None:
+    """List all email accounts."""
+    from .server import list_accounts
+
+    try:
+        result = _run_async(list_accounts())
+        _print_json(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+@app.command(name="mailboxes")
+def cli_mailboxes(
+    account: Annotated[
+        str | None,
+        cyclopts.Parameter(name=["--account", "-a"], help="Account name"),
+    ] = None,
+) -> None:
+    """List mailboxes for an account."""
+    from .server import list_mailboxes
+
+    try:
+        result = _run_async(list_mailboxes(account))
+        _print_json(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+@app.command(name="extract")
+def cli_extract(
+    message_id: int,
+    filename: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help="Attachment filename (omit for links)",
+        ),
+    ] = None,
+    account: Annotated[
+        str | None,
+        cyclopts.Parameter(name=["--account", "-a"], help="Account name"),
+    ] = None,
+    mailbox: Annotated[
+        str | None,
+        cyclopts.Parameter(name=["--mailbox", "-m"], help="Mailbox name"),
+    ] = None,
+) -> None:
+    """Extract attachment or links from an email."""
+    from .server import get_email_attachment, get_email_links
+
+    try:
+        if filename:
+            result = _run_async(
+                get_email_attachment(
+                    message_id, filename, account=account, mailbox=mailbox
+                )
+            )
+        else:
+            result = _run_async(
+                get_email_links(message_id, account=account, mailbox=mailbox)
+            )
+        _print_json(result)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
 
 def main() -> None:

--- a/src/apple_mail_mcp/config.py
+++ b/src/apple_mail_mcp/config.py
@@ -95,3 +95,34 @@ def get_index_staleness_hours() -> float:
         Staleness threshold in hours.
     """
     return float(os.environ.get("APPLE_MAIL_INDEX_STALENESS_HOURS", "24"))
+
+
+# ========== Server Mode ==========
+
+_read_only_mode: bool = False
+
+
+def get_read_only_mode() -> bool:
+    """
+    Check if write operations are disabled.
+
+    Set ``APPLE_MAIL_READ_ONLY`` environment variable or call
+    :func:`set_read_only_mode` to enable.  When enabled, write
+    tools (v0.3.0+) will refuse to execute.
+
+    Returns:
+        True if read-only mode is active.
+    """
+    if _read_only_mode:
+        return True
+    return os.environ.get("APPLE_MAIL_READ_ONLY", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def set_read_only_mode(value: bool) -> None:
+    """Enable or disable read-only mode programmatically."""
+    global _read_only_mode
+    _read_only_mode = value

--- a/src/apple_mail_mcp/index/disk.py
+++ b/src/apple_mail_mcp/index/disk.py
@@ -42,7 +42,45 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 # Mail.app version folder (V10 for macOS Catalina+)
+# Deprecated: use find_mail_directory() which auto-detects.
 MAIL_VERSION = "V10"
+
+# Cached result of find_mail_directory()
+_cached_mail_dir: Path | None = None
+
+
+def _detect_mail_version() -> str:
+    """Auto-detect the highest Mail.app version directory.
+
+    Scans ``~/Library/Mail/`` for directories matching ``V<number>``
+    and returns the highest version (e.g. ``"V11"`` if V10 and V11
+    both exist).  Falls back to ``"V10"`` if none are found.
+
+    Returns:
+        Version string like ``"V10"`` or ``"V11"``.
+    """
+    mail_base = Path.home() / "Library" / "Mail"
+    if not mail_base.is_dir():
+        return MAIL_VERSION
+
+    versions: list[tuple[int, str]] = []
+    try:
+        for entry in mail_base.iterdir():
+            if (
+                entry.is_dir()
+                and entry.name.startswith("V")
+                and entry.name[1:].isdigit()
+            ):
+                versions.append((int(entry.name[1:]), entry.name))
+    except PermissionError:
+        return MAIL_VERSION
+
+    if not versions:
+        return MAIL_VERSION
+
+    # Return highest version
+    versions.sort()
+    return versions[-1][1]
 
 
 def extract_message_id(path: Path) -> int:
@@ -100,14 +138,23 @@ def find_mail_directory() -> Path:
     """
     Find the Apple Mail data directory.
 
+    Auto-detects the highest ``V*`` version directory under
+    ``~/Library/Mail/``.  The result is cached for the lifetime
+    of the process.
+
     Returns:
-        Path to ~/Library/Mail/V10/
+        Path to the Mail data directory (e.g. ``~/Library/Mail/V10/``)
 
     Raises:
         FileNotFoundError: If directory doesn't exist
         PermissionError: If Full Disk Access is not granted
     """
-    mail_dir = Path.home() / "Library" / "Mail" / MAIL_VERSION
+    global _cached_mail_dir
+    if _cached_mail_dir is not None:
+        return _cached_mail_dir
+
+    version = _detect_mail_version()
+    mail_dir = Path.home() / "Library" / "Mail" / version
 
     if not mail_dir.exists():
         raise FileNotFoundError(
@@ -122,9 +169,11 @@ def find_mail_directory() -> Path:
         raise PermissionError(
             f"Cannot access {mail_dir}\n"
             "Grant Full Disk Access to Terminal:\n"
-            "  System Settings → Privacy & Security → Full Disk Access"
+            "  System Settings → Privacy & Security → "
+            "Full Disk Access"
         ) from e
 
+    _cached_mail_dir = mail_dir
     return mail_dir
 
 

--- a/src/apple_mail_mcp/index/manager.py
+++ b/src/apple_mail_mcp/index/manager.py
@@ -423,6 +423,10 @@ class IndexManager:
         limit: int = 20,
         exclude_mailboxes: list[str] | None = None,
         column: str | None = None,
+        *,
+        before: str | None = None,
+        after: str | None = None,
+        highlight: bool = False,
     ) -> list[SearchResult]:
         """
         Search indexed emails using FTS5.
@@ -435,13 +439,17 @@ class IndexManager:
             exclude_mailboxes: Mailboxes to exclude from results
             column: Optional FTS5 column filter ("subject", "sender",
                 or "content")
+            before: Exclude emails on/after this date (YYYY-MM-DD)
+            after: Include emails on/after this date (YYYY-MM-DD)
+            highlight: Use FTS5 highlight/snippet for results
 
         Returns:
             List of SearchResult ordered by relevance (BM25 score)
         """
-        from .search import search_fts
+        from .search import search_fts, search_fts_highlight
 
-        return search_fts(
+        search_fn = search_fts_highlight if highlight else search_fts
+        return search_fn(
             self._get_conn(),
             query,
             account=account,
@@ -449,6 +457,8 @@ class IndexManager:
             limit=limit,
             column=column,
             exclude_mailboxes=exclude_mailboxes,
+            before=before,
+            after=after,
         )
 
     def rebuild(
@@ -604,6 +614,9 @@ class IndexManager:
         mailbox: str | None = None,
         limit: int = 20,
         exclude_mailboxes: list[str] | None = None,
+        *,
+        before: str | None = None,
+        after: str | None = None,
     ) -> list[dict]:
         """Search attachments by filename using SQL LIKE.
 
@@ -613,6 +626,8 @@ class IndexManager:
             mailbox: Optional mailbox filter
             limit: Maximum results
             exclude_mailboxes: Mailboxes to exclude from results
+            before: Exclude emails on/after this date (YYYY-MM-DD)
+            after: Include emails on/after this date (YYYY-MM-DD)
 
         Returns:
             List of dicts with message_id, account, mailbox,
@@ -627,6 +642,8 @@ class IndexManager:
             mailbox=mailbox,
             limit=limit,
             exclude_mailboxes=exclude_mailboxes,
+            before=before,
+            after=after,
         )
 
     def get_email_attachments(

--- a/src/apple_mail_mcp/index/search.py
+++ b/src/apple_mail_mcp/index/search.py
@@ -149,11 +149,16 @@ def add_account_mailbox_filter(
         sql += f" AND {table_alias}.account = ?"
         params.append(account)
     if mailbox:
-        sql += f" AND {table_alias}.mailbox = ?"
+        sql += f" AND LOWER({table_alias}.mailbox) = LOWER(?)"
         params.append(mailbox)
     if exclude_mailboxes:
-        placeholders = ", ".join("?" for _ in exclude_mailboxes)
-        sql += f" AND {table_alias}.mailbox NOT IN ({placeholders})"
+        placeholders = ", ".join(
+            "LOWER(?)" for _ in exclude_mailboxes
+        )
+        sql += (
+            f" AND LOWER({table_alias}.mailbox)"
+            f" NOT IN ({placeholders})"
+        )
         params.extend(exclude_mailboxes)
     if after:
         sql += f" AND {table_alias}.date_received >= ?"

--- a/src/apple_mail_mcp/index/search.py
+++ b/src/apple_mail_mcp/index/search.py
@@ -152,13 +152,8 @@ def add_account_mailbox_filter(
         sql += f" AND LOWER({table_alias}.mailbox) = LOWER(?)"
         params.append(mailbox)
     if exclude_mailboxes:
-        placeholders = ", ".join(
-            "LOWER(?)" for _ in exclude_mailboxes
-        )
-        sql += (
-            f" AND LOWER({table_alias}.mailbox)"
-            f" NOT IN ({placeholders})"
-        )
+        placeholders = ", ".join("LOWER(?)" for _ in exclude_mailboxes)
+        sql += f" AND LOWER({table_alias}.mailbox) NOT IN ({placeholders})"
         params.extend(exclude_mailboxes)
     if after:
         sql += f" AND {table_alias}.date_received >= ?"

--- a/src/apple_mail_mcp/index/search.py
+++ b/src/apple_mail_mcp/index/search.py
@@ -122,9 +122,12 @@ def add_account_mailbox_filter(
     mailbox: str | None,
     table_alias: str = "e",
     exclude_mailboxes: list[str] | None = None,
+    *,
+    before: str | None = None,
+    after: str | None = None,
 ) -> str:
     """
-    Add account/mailbox WHERE clauses to a SQL query.
+    Add account/mailbox/date WHERE clauses to a SQL query.
 
     This helper reduces repetition when building filtered queries.
     Modifies params in-place and returns the updated SQL string.
@@ -136,6 +139,8 @@ def add_account_mailbox_filter(
         mailbox: Optional mailbox filter
         table_alias: Table alias prefix (default: "e")
         exclude_mailboxes: Optional list of mailboxes to exclude
+        before: Exclude emails on/after this date (YYYY-MM-DD)
+        after: Include emails on/after this date (YYYY-MM-DD)
 
     Returns:
         Updated SQL string with added WHERE clauses
@@ -150,6 +155,12 @@ def add_account_mailbox_filter(
         placeholders = ", ".join("?" for _ in exclude_mailboxes)
         sql += f" AND {table_alias}.mailbox NOT IN ({placeholders})"
         params.extend(exclude_mailboxes)
+    if after:
+        sql += f" AND {table_alias}.date_received >= ?"
+        params.append(after)
+    if before:
+        sql += f" AND {table_alias}.date_received < ?"
+        params.append(before)
     return sql
 
 
@@ -225,6 +236,8 @@ def search_fts(
     *,
     column: str | None = None,
     exclude_mailboxes: list[str] | None = None,
+    before: str | None = None,
+    after: str | None = None,
     _is_retry: bool = False,
 ) -> list[SearchResult]:
     """
@@ -239,6 +252,8 @@ def search_fts(
         column: Optional FTS5 column filter ("subject", "sender",
             or "content"). Prepended as ``column:query`` after
             sanitization so the prefix isn't escaped.
+        before: Exclude emails on/after this date (YYYY-MM-DD)
+        after: Include emails on/after this date (YYYY-MM-DD)
 
     Returns:
         List of SearchResult ordered by relevance (BM25 score)
@@ -285,6 +300,8 @@ def search_fts(
         account,
         mailbox,
         exclude_mailboxes=exclude_mailboxes,
+        before=before,
+        after=after,
     )
     sql += " ORDER BY score DESC LIMIT ?"
     params.append(limit)
@@ -322,6 +339,8 @@ def search_fts(
                 limit=limit,
                 column=column,
                 exclude_mailboxes=exclude_mailboxes,
+                before=before,
+                after=after,
                 _is_retry=True,
             )
         raise
@@ -333,12 +352,19 @@ def search_fts_highlight(
     account: str | None = None,
     mailbox: str | None = None,
     limit: int = 20,
+    *,
+    column: str | None = None,
+    exclude_mailboxes: list[str] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    _is_retry: bool = False,
 ) -> list[SearchResult]:
     """
     Search with highlighted snippets showing match context.
 
-    Similar to search_fts but uses FTS5 highlight() function
-    to mark matched terms in the content.
+    Uses FTS5 ``highlight()`` and ``snippet()`` to wrap matched
+    terms in ``**`` markers.  Falls back to :func:`search_fts`
+    on any FTS5 error.
 
     Args:
         conn: Database connection
@@ -346,6 +372,10 @@ def search_fts_highlight(
         account: Optional account filter
         mailbox: Optional mailbox filter
         limit: Maximum results
+        column: Optional FTS5 column filter
+        exclude_mailboxes: Mailboxes to exclude
+        before: Exclude emails on/after this date (YYYY-MM-DD)
+        after: Include emails on/after this date (YYYY-MM-DD)
 
     Returns:
         List of SearchResult with highlighted content_snippet
@@ -353,11 +383,14 @@ def search_fts_highlight(
     if not query or not query.strip():
         return []
 
-    safe_query = sanitize_fts_query(query)
+    safe_query = query if _is_retry else sanitize_fts_query(query)
+
+    if column and column in ("subject", "sender", "content"):
+        safe_query = f"{column}:({safe_query})"
+
     if not safe_query:
         return []
 
-    # Use highlight() to mark matches with ** markers
     sql = """
         SELECT
             e.message_id,
@@ -365,7 +398,8 @@ def search_fts_highlight(
             e.mailbox,
             highlight(emails_fts, 0, '**', '**') as subject_hl,
             e.sender,
-            snippet(emails_fts, 2, '**', '**', '...', 32) as content_snippet,
+            snippet(emails_fts, 2, '**', '**', '...', 32)
+                as content_snippet,
             e.date_received,
             -bm25(emails_fts, 1.0, 0.5, 2.0) as score
         FROM emails_fts
@@ -374,7 +408,15 @@ def search_fts_highlight(
     """
 
     params: list = [safe_query]
-    sql = add_account_mailbox_filter(sql, params, account, mailbox)
+    sql = add_account_mailbox_filter(
+        sql,
+        params,
+        account,
+        mailbox,
+        exclude_mailboxes=exclude_mailboxes,
+        before=before,
+        after=after,
+    )
     sql += " ORDER BY score DESC LIMIT ?"
     params.append(limit)
 
@@ -385,22 +427,46 @@ def search_fts_highlight(
         for row in cursor:
             results.append(
                 SearchResult(
-                    id=row[0],
-                    account=row[1],
-                    mailbox=row[2],
-                    subject=row[3] or "",
-                    sender=row[4] or "",
-                    content_snippet=row[5] or "",
-                    date_received=row[6] or "",
-                    score=round(row[7], 3),
+                    id=row["message_id"],
+                    account=row["account"],
+                    mailbox=row["mailbox"],
+                    subject=row["subject_hl"] or "",
+                    sender=row["sender"] or "",
+                    content_snippet=row["content_snippet"] or "",
+                    date_received=row["date_received"] or "",
+                    score=round(row["score"], 3),
                 )
             )
 
         return results
 
-    except sqlite3.OperationalError:
-        # Fall back to basic search
-        return search_fts(conn, query, account, mailbox, limit)
+    except sqlite3.OperationalError as e:
+        if "fts5: syntax error" in str(e).lower() and not _is_retry:
+            escaped = _escape_all_special(query)
+            return search_fts_highlight(
+                conn,
+                escaped,
+                account=account,
+                mailbox=mailbox,
+                limit=limit,
+                column=column,
+                exclude_mailboxes=exclude_mailboxes,
+                before=before,
+                after=after,
+                _is_retry=True,
+            )
+        # Fall back to basic search on other errors
+        return search_fts(
+            conn,
+            query,
+            account,
+            mailbox,
+            limit,
+            column=column,
+            exclude_mailboxes=exclude_mailboxes,
+            before=before,
+            after=after,
+        )
 
 
 def count_matches(
@@ -454,6 +520,9 @@ def search_attachments(
     mailbox: str | None = None,
     limit: int = 20,
     exclude_mailboxes: list[str] | None = None,
+    *,
+    before: str | None = None,
+    after: str | None = None,
 ) -> list[dict]:
     """Search attachments by filename using SQL LIKE.
 
@@ -466,6 +535,8 @@ def search_attachments(
         mailbox: Optional mailbox filter
         limit: Maximum results
         exclude_mailboxes: Mailboxes to exclude
+        before: Exclude emails on/after this date (YYYY-MM-DD)
+        after: Include emails on/after this date (YYYY-MM-DD)
 
     Returns:
         List of dicts with message_id, account, mailbox,
@@ -482,7 +553,13 @@ def search_attachments(
     """
     params: list = [like_pattern]
     sql = add_account_mailbox_filter(
-        sql, params, account, mailbox, exclude_mailboxes=exclude_mailboxes
+        sql,
+        params,
+        account,
+        mailbox,
+        exclude_mailboxes=exclude_mailboxes,
+        before=before,
+        after=after,
     )
     sql += " ORDER BY e.date_received DESC LIMIT ?"
     params.append(limit)

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -565,59 +565,16 @@ class AttachmentContent(TypedDict, total=False):
     links: list[LinkResult]
 
 
-@mcp.tool
-async def get_attachment(
+async def _resolve_emlx_path(
     message_id: int,
-    filename: str | None = None,
     account: str | None = None,
     mailbox: str | None = None,
-) -> AttachmentContent:
+) -> _Path:
+    """Resolve a message ID to an .emlx file path via the index.
+
+    Raises:
+        ValueError: If the index is missing or email not found.
     """
-    Extract resources from an email: attachments or links.
-
-    This tool has two modes based on the filename parameter:
-
-    **Attachment mode** (filename provided):
-    Extracts the named file attachment and saves it to disk under
-    ~/.apple-mail-mcp/attachments/. Parses the raw MIME structure,
-    so it works for all attachment types including inline images
-    and S/MIME signatures.
-
-    **Links mode** (filename omitted):
-    Extracts all hyperlinks from the email's HTML content.
-    Filters out mailto:, javascript:, and long tracking URLs.
-    Returns deduplicated links with their anchor text.
-
-    Requires the search index. If upgrading from v0.1.2, run
-    'apple-mail-mcp rebuild' to populate attachment metadata.
-
-    Args:
-        message_id: The email's unique ID
-        filename: Attachment filename to extract. If omitted,
-            returns links instead.
-        account: Account name (optional, used for index lookup)
-        mailbox: Mailbox name (optional, used for index lookup)
-
-    Returns:
-        With filename: dict with filename, mime_type, size,
-            and file_path pointing to the saved file.
-        Without filename: dict with links list, each having
-            url and text fields.
-
-    Examples:
-        >>> get_attachment(12345, "invoice.pdf")
-        {"filename": "invoice.pdf", ...}
-        >>> get_attachment(12345)
-        {"links": [{"url": "https://...", "text": "Click"}]}
-    """
-    # Clean up old cached attachments (best-effort, non-blocking)
-    try:
-        await asyncio.to_thread(_cleanup_old_attachments)
-    except Exception:
-        pass  # Cleanup failure should not block attachment extraction
-
-    # Look up emlx_path from the index, scoped by account/mailbox
-    # when provided (message_id is only unique within a mailbox)
     manager = _get_index_manager()
     if not manager.has_index():
         raise ValueError("No search index. Run 'apple-mail-mcp index'.")
@@ -633,17 +590,81 @@ async def get_attachment(
     )
     if not emlx_path:
         raise ValueError(f"Email {message_id} not found in index.")
+    return emlx_path
 
-    # Links mode: extract hyperlinks from HTML parts
-    if filename is None:
-        from .index.disk import get_email_links
 
-        link_infos = await asyncio.to_thread(get_email_links, emlx_path)
-        return {
-            "links": [{"url": li.url, "text": li.text} for li in link_infos],
-        }
+@mcp.tool
+async def get_email_links(
+    message_id: int,
+    account: str | None = None,
+    mailbox: str | None = None,
+) -> dict:
+    """
+    Extract hyperlinks from an email's HTML content.
 
-    # Attachment mode: extract and save file
+    Filters out mailto:, javascript:, and long tracking URLs.
+    Returns deduplicated links with their anchor text.
+
+    Requires the search index.
+
+    Args:
+        message_id: The email's unique ID
+        account: Account name (optional, speeds up lookup)
+        mailbox: Mailbox name (optional, speeds up lookup)
+
+    Returns:
+        Dict with 'links' list, each having 'url' and 'text'.
+
+    Example:
+        >>> get_email_links(12345)
+        {"links": [{"url": "https://...", "text": "Click"}]}
+    """
+    emlx_path = await _resolve_emlx_path(message_id, account, mailbox)
+    from .index.disk import get_email_links as _get_links
+
+    link_infos = await asyncio.to_thread(_get_links, emlx_path)
+    return {
+        "links": [{"url": li.url, "text": li.text} for li in link_infos],
+    }
+
+
+@mcp.tool
+async def get_email_attachment(
+    message_id: int,
+    filename: str,
+    account: str | None = None,
+    mailbox: str | None = None,
+) -> AttachmentContent:
+    """
+    Extract a file attachment from an email and save to disk.
+
+    Saves the attachment under ~/.apple-mail-mcp/attachments/.
+    Parses the raw MIME structure, so it works for all attachment
+    types including inline images and S/MIME signatures.
+
+    Requires the search index.
+
+    Args:
+        message_id: The email's unique ID
+        filename: Attachment filename to extract
+        account: Account name (optional, speeds up lookup)
+        mailbox: Mailbox name (optional, speeds up lookup)
+
+    Returns:
+        Dict with filename, mime_type, size, and file_path
+        pointing to the saved file.
+
+    Example:
+        >>> get_email_attachment(12345, "invoice.pdf")
+        {"filename": "invoice.pdf", "file_path": "/...", ...}
+    """
+    # Clean up old cached attachments (best-effort)
+    try:
+        await asyncio.to_thread(_cleanup_old_attachments)
+    except Exception:
+        pass
+
+    emlx_path = await _resolve_emlx_path(message_id, account, mailbox)
     from .index.disk import get_attachment_content
 
     result = await asyncio.to_thread(
@@ -660,7 +681,7 @@ async def get_attachment(
     ATTACHMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     ATTACHMENT_CACHE_DIR.chmod(0o700)
     save_dir = _Path(tempfile.mkdtemp(dir=ATTACHMENT_CACHE_DIR))
-    safe_name = _Path(filename).name  # strip directory components
+    safe_name = _Path(filename).name
     file_path = save_dir / safe_name
     file_path.write_bytes(raw_bytes)
 
@@ -673,6 +694,32 @@ async def get_attachment(
 
 
 @mcp.tool
+async def get_attachment(
+    message_id: int,
+    filename: str | None = None,
+    account: str | None = None,
+    mailbox: str | None = None,
+) -> AttachmentContent:
+    """
+    DEPRECATED: Use get_email_attachment() or get_email_links().
+
+    Extract resources from an email: attachments or links.
+    Delegates to get_email_links (filename omitted) or
+    get_email_attachment (filename provided).
+
+    Args:
+        message_id: The email's unique ID
+        filename: Attachment filename to extract. If omitted,
+            returns links instead.
+        account: Account name (optional)
+        mailbox: Mailbox name (optional)
+    """
+    if filename is None:
+        return await get_email_links(message_id, account, mailbox)
+    return await get_email_attachment(message_id, filename, account, mailbox)
+
+
+@mcp.tool
 async def search(
     query: str,
     account: str | None = None,
@@ -680,6 +727,9 @@ async def search(
     scope: Literal["all", "subject", "sender", "body", "attachments"] = "all",
     limit: int = 20,
     exclude_mailboxes: list[str] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    highlight: bool = False,
 ) -> list[SearchResult] | dict:
     """
     Search emails across all accounts and mailboxes.
@@ -707,6 +757,10 @@ async def search(
             - "attachments": Attachment filenames
         limit: Maximum results (default: 20)
         exclude_mailboxes: Mailboxes to exclude (default: ["Drafts"])
+        before: Exclude emails on/after this date (YYYY-MM-DD).
+        after: Include only emails on/after this date (YYYY-MM-DD).
+        highlight: Wrap matched terms in **markers** in subject
+            and content_snippet (default: False).
 
     Returns:
         List of matching emails with id, subject, sender,
@@ -718,6 +772,7 @@ async def search(
         >>> search("quarterly budget")  # Keywords, not sentences
         >>> search('"project update"')  # Exact phrase
         >>> search("invoice.pdf", scope="attachments")
+        >>> search("budget", after="2026-01-01", before="2026-04-01")
     """
     if exclude_mailboxes is None:
         exclude_mailboxes = ["Drafts"]
@@ -750,6 +805,8 @@ async def search(
             mailbox=mailbox,
             limit=limit,
             exclude_mailboxes=exclude_mailboxes,
+            before=before,
+            after=after,
         )
 
         acct_map = _get_account_map()
@@ -809,6 +866,9 @@ async def search(
                     limit=limit,
                     exclude_mailboxes=exclude_mailboxes,
                     column=fts_column,
+                    before=before,
+                    after=after,
+                    highlight=highlight,
                 )
             except Exception as e:
                 err_msg = str(e) or repr(e)
@@ -836,6 +896,13 @@ async def search(
                     for r in results
                 ]
             )
+
+    # Date filtering and highlight require the FTS5 index
+    if before or after:
+        raise ValueError(
+            "Date filtering (before/after) requires the search "
+            "index. Run 'apple-mail-mcp index' to build it."
+        )
 
     # JXA-based search for subject/sender or when no index
     safe_query_js = json.dumps(query.lower())

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -1017,3 +1017,72 @@ Content-Disposition: attachment; filename="doc.pdf"
         assert len(result) == 1
         assert result[0].filename == "doc.pdf"
         assert result[0].file_size > 0
+
+
+class TestDetectMailVersion:
+    """Tests for dynamic Mail.app version detection."""
+
+    def test_finds_highest_version(self, tmp_path: Path, monkeypatch):
+        """Returns the highest V* directory numerically."""
+        mail_base = tmp_path / "Library" / "Mail"
+        (mail_base / "V9").mkdir(parents=True)
+        (mail_base / "V10").mkdir()
+        (mail_base / "V11").mkdir()
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from apple_mail_mcp.index.disk import _detect_mail_version
+
+        assert _detect_mail_version() == "V11"
+
+    def test_fallback_to_v10(self, tmp_path: Path, monkeypatch):
+        """Returns V10 when no V* directories exist."""
+        mail_base = tmp_path / "Library" / "Mail"
+        mail_base.mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from apple_mail_mcp.index.disk import _detect_mail_version
+
+        assert _detect_mail_version() == "V10"
+
+    def test_ignores_non_version_dirs(self, tmp_path: Path, monkeypatch):
+        """Ignores directories that don't match V<number> pattern."""
+        mail_base = tmp_path / "Library" / "Mail"
+        (mail_base / "V10").mkdir(parents=True)
+        (mail_base / "Bundles").mkdir()
+        (mail_base / "Vx").mkdir()
+        (mail_base / "V").mkdir()
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from apple_mail_mcp.index.disk import _detect_mail_version
+
+        assert _detect_mail_version() == "V10"
+
+    def test_fallback_when_no_mail_dir(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Returns V10 when ~/Library/Mail doesn't exist."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from apple_mail_mcp.index.disk import _detect_mail_version
+
+        assert _detect_mail_version() == "V10"
+
+    def test_find_mail_directory_caches(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """find_mail_directory() caches its result."""
+        import apple_mail_mcp.index.disk as disk_mod
+
+        mail_dir = tmp_path / "Library" / "Mail" / "V10"
+        mail_dir.mkdir(parents=True)
+        (mail_dir / "account-uuid").mkdir()
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Clear cache
+        disk_mod._cached_mail_dir = None
+
+        result1 = disk_mod.find_mail_directory()
+        result2 = disk_mod.find_mail_directory()
+        assert result1 == result2 == mail_dir
+
+        # Clean up cache for other tests
+        disk_mod._cached_mail_dir = None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sqlite3
 
+import pytest
+
 from apple_mail_mcp.index.search import (
     _escape_all_special,
     count_matches,
@@ -11,7 +13,50 @@ from apple_mail_mcp.index.search import (
     sanitize_fts_query,
     search_attachments,
     search_fts,
+    search_fts_highlight,
 )
+
+
+@pytest.fixture
+def fts_db():
+    """In-memory FTS5 database with test emails."""
+    from apple_mail_mcp.index.schema import create_connection
+
+    conn = create_connection(":memory:")
+
+    from apple_mail_mcp.index.schema import get_schema_sql
+
+    conn.executescript(get_schema_sql())
+
+    # Insert test emails with different dates
+    emails = [
+        (1, "acct-1", "Inbox", "Budget meeting notes",
+         "alice@example.com", "Let's discuss the Q1 budget",
+         "2026-01-15T10:00:00"),
+        (2, "acct-1", "Inbox", "Project update",
+         "bob@example.com", "The project is on track",
+         "2026-02-10T14:00:00"),
+        (3, "acct-1", "Sent", "Re: Budget meeting notes",
+         "me@example.com", "Thanks for the budget update",
+         "2026-03-01T09:00:00"),
+        (4, "acct-2", "Inbox", "Invoice attached",
+         "vendor@example.com", "Please find the invoice",
+         "2026-03-15T16:00:00"),
+    ]
+    for msg_id, acct, mbox, subj, sender, content, date in emails:
+        conn.execute(
+            "INSERT INTO emails "
+            "(message_id, account, mailbox, subject, sender, "
+            "content, date_received) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (msg_id, acct, mbox, subj, sender, content, date),
+        )
+    # Populate FTS5 index
+    conn.execute(
+        "INSERT INTO emails_fts(emails_fts) VALUES('rebuild')"
+    )
+    conn.commit()
+    return conn
 
 
 class TestSanitizeFtsQuery:
@@ -365,3 +410,105 @@ class TestDetectMatchedColumns:
         result.sender = "a@b.com"
 
         assert detect_matched_columns("!!!", result) == "body"
+
+
+class TestDateRangeFiltering:
+    """Tests for before/after date filtering in search."""
+
+    def test_after_filter(self, fts_db):
+        results = search_fts(
+            fts_db, "budget", after="2026-02-01"
+        )
+        assert len(results) == 1
+        assert results[0].id == 3  # March email only
+
+    def test_before_filter(self, fts_db):
+        results = search_fts(
+            fts_db, "budget", before="2026-02-01"
+        )
+        assert len(results) == 1
+        assert results[0].id == 1  # January email only
+
+    def test_both_filters(self, fts_db):
+        results = search_fts(
+            fts_db,
+            "budget OR project OR invoice",
+            after="2026-02-01",
+            before="2026-03-10",
+        )
+        # Should get emails 2 (Feb) and 3 (Mar 1) but not 1 or 4
+        ids = {r.id for r in results}
+        assert ids == {2, 3}
+
+    def test_date_with_account(self, fts_db):
+        results = search_fts(
+            fts_db,
+            "budget OR project OR invoice",
+            account="acct-1",
+            after="2026-02-01",
+        )
+        ids = {r.id for r in results}
+        assert 4 not in ids  # acct-2 excluded
+
+    def test_no_date_filter(self, fts_db):
+        results = search_fts(fts_db, "budget")
+        assert len(results) == 2  # Both budget emails
+
+    def test_date_filter_attachments(self, fts_db):
+        # Add attachment data
+        fts_db.execute(
+            "INSERT INTO attachments "
+            "(email_rowid, filename, mime_type, file_size) "
+            "VALUES (1, 'budget.pdf', 'application/pdf', 1024)"
+        )
+        fts_db.execute(
+            "INSERT INTO attachments "
+            "(email_rowid, filename, mime_type, file_size) "
+            "VALUES (4, 'invoice.pdf', 'application/pdf', 2048)"
+        )
+        fts_db.commit()
+
+        results = search_attachments(
+            fts_db, "pdf", after="2026-03-01"
+        )
+        assert len(results) == 1
+        assert results[0]["filename"] == "invoice.pdf"
+
+
+class TestSearchFtsHighlight:
+    """Tests for highlighted search results."""
+
+    def test_highlight_basic(self, fts_db):
+        results = search_fts_highlight(fts_db, "budget")
+        assert len(results) == 2
+        # At least one result should have ** markers
+        has_markers = any(
+            "**" in r.subject or "**" in r.content_snippet
+            for r in results
+        )
+        assert has_markers
+
+    def test_highlight_with_account_filter(self, fts_db):
+        results = search_fts_highlight(
+            fts_db, "budget", account="acct-1"
+        )
+        assert all(r.account == "acct-1" for r in results)
+
+    def test_highlight_with_date_range(self, fts_db):
+        results = search_fts_highlight(
+            fts_db, "budget", after="2026-02-01"
+        )
+        assert len(results) == 1
+        assert results[0].id == 3
+
+    def test_highlight_with_exclude_mailboxes(self, fts_db):
+        results = search_fts_highlight(
+            fts_db, "budget", exclude_mailboxes=["Sent"]
+        )
+        assert all(r.mailbox != "Sent" for r in results)
+
+    def test_highlight_fallback_on_error(self, fts_db):
+        # Corrupt query that might cause highlight to fail
+        # but search_fts handles via retry
+        results = search_fts_highlight(fts_db, "budget")
+        assert isinstance(results, list)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -412,6 +412,30 @@ class TestDetectMatchedColumns:
         assert detect_matched_columns("!!!", result) == "body"
 
 
+class TestMailboxCaseInsensitive:
+    """Tests for case-insensitive mailbox filtering (#67)."""
+
+    def test_mailbox_case_insensitive(self, fts_db):
+        """Mailbox filter should match regardless of case."""
+        # fts_db has mailboxes: "Inbox" and "Sent"
+        r1 = search_fts(fts_db, "budget", mailbox="Inbox")
+        r2 = search_fts(fts_db, "budget", mailbox="inbox")
+        r3 = search_fts(fts_db, "budget", mailbox="INBOX")
+        assert len(r1) == len(r2) == len(r3)
+        assert len(r1) > 0
+
+    def test_exclude_mailbox_case_insensitive(self, fts_db):
+        """Excluded mailboxes should match regardless of case."""
+        r1 = search_fts(
+            fts_db, "budget", exclude_mailboxes=["Sent"]
+        )
+        r2 = search_fts(
+            fts_db, "budget", exclude_mailboxes=["sent"]
+        )
+        assert len(r1) == len(r2)
+        assert all(r.mailbox != "Sent" for r in r1)
+
+
 class TestDateRangeFiltering:
     """Tests for before/after date filtering in search."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.1.8"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

v0.2.0 doubles down on search and retrieval quality before introducing write operations in v0.3.0.

- **Date-range filtering** — `before`/`after` params on `search()` (YYYY-MM-DD) (#9)
- **Highlighted search results** — `highlight=True` wraps matched terms in `**markers**` (#11)
- **Split get_attachment** — new `get_email_links()` + `get_email_attachment()` tools, old tool deprecated (#55)
- **Dynamic Mail version detection** — auto-detects highest `V*` dir, no more hardcoded V10 (#57)
- **CLI wrappers** — `search`, `read`, `emails`, `accounts`, `mailboxes`, `extract` commands (#61)
- **Skill generator** — `apple-mail-mcp integrate claude` outputs a Claude Code skill file (#62)
- **`--read-only` server flag** — prep for v0.3.0 write ops (#63)

Also includes all v0.1.8 bug fixes (watcher crash, attachment cache leak, search error messages, timeout message).

## Test plan

- [x] 313 unit tests pass (16 new)
- [x] 31/31 integration tests pass (8 new for v0.2.0 features)
- [x] CLI commands verified manually (search, read, accounts, integrate)
- [x] Lint + format clean
- [x] Update docs (tools.md, configuration.md, search.md, README)
- [x] Update integration test spec (integration/CLAUDE.md)

## Known gaps (pre-merge)

- Docs not yet updated for new tools/params/CLI commands
- CLI commands not unit-tested (thin wrappers, underlying functions tested)
- `--read-only` flag accepted but not enforced (by design — v0.3.0 adds write tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)