### PR TITLE
Fix external attachment lookup for nested MIME parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **External-attachment lookup for nested MIME parts** — Apple Mail stores externally-referenced attachments under `Attachments/<msg_id>/<part>/` where `<part>` is an RFC-style MIME part number. Top-level parts use flat integers (`2/`), but nested parts (common in forwarded emails: `multipart/mixed > multipart/mixed > application/pdf`) use dot notation (`2.2/`, `1.16/`, etc.). The previous implementation tracked a flat attachment counter and routed every lookup to a top-level subdir, so any nested attachment came back as `size: 0` from `parse_emlx()` and `None` from `get_attachment_content()`. New `_mime_part_numbers()` helper walks the MIME tree and builds an `id(part) → "2.2"` map; `_extract_attachments()`, `get_attachment_content()`, and `_find_external_attachment()` now use real part numbers instead of the flat counter. Scoped check against a real ~72K-message mailbox: 4,063 dot-notation subdirs (~18% of all attachments) were affected; flat-attachment behavior is preserved (regression test included). Thanks to @scottwb for the fix and tests. (#85)
+
 ## [0.3.2] - 2026-05-10
 
 ### Added

--- a/src/apple_mail_mcp/index/disk.py
+++ b/src/apple_mail_mcp/index/disk.py
@@ -633,12 +633,10 @@ def _mime_part_numbers(
     """
     result: dict[int, str] = {}
 
-    def _walk(
-        part: email.message.Message, prefix: list[str]
-    ) -> None:
+    def _walk(part: email.message.Message, prefix: list[str]) -> None:
         if part.is_multipart():
             for i, child in enumerate(part.get_payload(), 1):
-                _walk(child, prefix + [str(i)])
+                _walk(child, [*prefix, str(i)])
         else:
             result[id(part)] = ".".join(prefix)
 

--- a/src/apple_mail_mcp/index/disk.py
+++ b/src/apple_mail_mcp/index/disk.py
@@ -621,10 +621,40 @@ def _estimate_attachment_size(part: email.message.Message) -> int:
         return len(raw)
 
 
+def _mime_part_numbers(
+    msg: email.message.Message,
+) -> dict[int, str]:
+    """Map ``id(part)`` to MIME part-number strings.
+
+    Top-level children of a multipart message are numbered
+    ``"1"``, ``"2"``, etc.  Nested children use dot notation
+    (``"2.1"``, ``"2.2"``), mirroring the subdirectory names
+    Apple Mail uses under ``Attachments/<msg_id>/``.
+    """
+    result: dict[int, str] = {}
+
+    def _walk(
+        part: email.message.Message, prefix: list[str]
+    ) -> None:
+        if part.is_multipart():
+            for i, child in enumerate(part.get_payload(), 1):
+                _walk(child, prefix + [str(i)])
+        else:
+            result[id(part)] = ".".join(prefix)
+
+    if msg.is_multipart():
+        for i, child in enumerate(msg.get_payload(), 1):
+            _walk(child, [str(i)])
+    else:
+        result[id(msg)] = "1"
+
+    return result
+
+
 def _find_external_attachment(
     emlx_path: Path,
     msg_id: int,
-    part_idx: int,
+    part_idx: int | str,
     filename: str,
 ) -> Path | None:
     """Find an externally-stored attachment on disk.
@@ -633,13 +663,14 @@ def _find_external_attachment(
     files in a sibling ``Attachments`` directory::
 
         .../Data/9/4/Messages/49461.partial.emlx
-        .../Data/9/4/Attachments/49461/2/file.jpeg
+        .../Data/9/4/Attachments/49461/2/file.jpeg        (top-level)
+        .../Data/9/4/Attachments/49461/2.2/file.pdf       (nested)
 
     Args:
         emlx_path: Path to the ``.emlx`` file.
         msg_id: Numeric message ID extracted from *emlx_path*.
-        part_idx: 1-based attachment part index (matches the
-            subdirectory name under ``Attachments/<msg_id>/``).
+        part_idx: MIME part number (e.g. ``2`` or ``"2.2"``),
+            matching the subdirectory under ``Attachments/<msg_id>/``.
         filename: Target filename to look for.
 
     Returns:
@@ -719,7 +750,7 @@ def _extract_attachments(
         except ValueError:
             pass
 
-    attachment_part_idx = 0
+    part_numbers = _mime_part_numbers(msg)
 
     for part in msg.walk():
         content_type = part.get_content_type()
@@ -737,19 +768,15 @@ def _extract_attachments(
         if not filename and "attachment" not in disposition.lower():
             continue
 
-        # 1-based index matching Attachments/ subdirs
-        attachment_part_idx += 1
-
         file_size = _estimate_attachment_size(part)
 
         # Fallback: stat external file for .partial.emlx
         if file_size == 0 and emlx_path is not None and msg_id is not None:
-            # Part subdirs start at 2 for the first
-            # attachment (1 is typically the body part)
+            part_number = part_numbers.get(id(part), "")
             ext = _find_external_attachment(
                 emlx_path,
                 msg_id,
-                attachment_part_idx + 1,
+                part_number,
                 filename,
             )
             if ext is not None:
@@ -804,9 +831,9 @@ def get_attachment_content(
         mime_end = mime_start + byte_count
         msg = email.message_from_bytes(content[mime_start:mime_end])
 
-        # Walk MIME parts, tracking attachment index for
+        # Walk MIME parts, using MIME part numbers for
         # external-file fallback.
-        attachment_part_idx = 0
+        part_numbers = _mime_part_numbers(msg)
         for part in msg.walk():
             ct = part.get_content_type()
             disp = str(part.get("Content-Disposition") or "")
@@ -822,8 +849,6 @@ def get_attachment_content(
             if not fname and "attachment" not in disp.lower():
                 continue
 
-            attachment_part_idx += 1
-
             if fname.strip().lower() != target_filename.strip().lower():
                 continue
 
@@ -833,9 +858,10 @@ def get_attachment_content(
                 return (payload, ct)
 
             # Fallback: external file on disk
+            part_number = part_numbers.get(id(part), "")
             result = _read_external_attachment(
                 emlx_path,
-                attachment_part_idx,
+                part_number,
                 target_filename,
             )
             if result is not None:
@@ -848,7 +874,7 @@ def get_attachment_content(
 
 def _read_external_attachment(
     emlx_path: Path,
-    attachment_part_idx: int,
+    part_number: int | str,
     target_filename: str,
 ) -> tuple[bytes, str] | None:
     """Read an external attachment file from disk.
@@ -859,7 +885,7 @@ def _read_external_attachment(
 
     Args:
         emlx_path: Path to the ``.emlx`` file.
-        attachment_part_idx: 1-based attachment index.
+        part_number: MIME part number (e.g. ``2`` or ``"2.2"``).
         target_filename: Filename to find.
 
     Returns:
@@ -873,7 +899,7 @@ def _read_external_attachment(
     ext_path = _find_external_attachment(
         emlx_path,
         msg_id,
-        attachment_part_idx + 1,
+        part_number,
         target_filename,
     )
     if ext_path is None:

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -10,6 +10,7 @@ from apple_mail_mcp.index.disk import (
     _extract_body_text,
     _find_external_attachment,
     _infer_account_mailbox,
+    _mime_part_numbers,
     _strip_html,
     get_attachment_content,
     parse_emlx,
@@ -769,16 +770,21 @@ class TestScanAllEmailsErrorHandling:
 def _build_partial_tree(
     tmp_path: Path,
     msg_id: int = 49461,
-    filenames: dict[int, str] | None = None,
+    filenames: dict[int | str, str] | None = None,
     file_content: bytes = b"\x89PNG fake image data",
+    mime_raw: bytes | None = None,
 ) -> Path:
     """Create a realistic .partial.emlx + Attachments tree.
 
     Returns the path to the ``.partial.emlx`` file.
 
-    ``filenames`` maps part-subdir index (e.g. 2, 3) to the
-    filename stored inside that directory.  Defaults to a
-    single attachment at subdir 2.
+    ``filenames`` maps part-subdir index (e.g. ``2``, ``3``,
+    or ``"2.2"`` for nested parts) to the filename stored
+    inside that directory.  Defaults to a single attachment
+    at subdir 2.
+
+    ``mime_raw`` optionally overrides the auto-generated MIME
+    content (for testing nested multipart structures).
     """
     if filenames is None:
         filenames = {2: "photo.jpeg"}
@@ -796,25 +802,26 @@ def _build_partial_tree(
     # Build a minimal .partial.emlx with an attachment
     # part whose payload is empty (simulates external
     # storage).
-    attachment_headers = ""
-    for fname in filenames.values():
-        attachment_headers += (
-            f"------=_Part\r\n"
-            f"Content-Type: application/octet-stream\r\n"
-            f'Content-Disposition: attachment; filename="{fname}"\r\n'
-            f"\r\n"
-        )
+    if mime_raw is None:
+        attachment_headers = ""
+        for fname in filenames.values():
+            attachment_headers += (
+                f"------=_Part\r\n"
+                f"Content-Type: application/octet-stream\r\n"
+                f'Content-Disposition: attachment; filename="{fname}"\r\n'
+                f"\r\n"
+            )
 
-    mime_raw = (
-        'Content-Type: multipart/mixed; boundary="----=_Part"\r\n'
-        "\r\n"
-        "------=_Part\r\n"
-        "Content-Type: text/plain\r\n"
-        "\r\n"
-        "Body text\r\n"
-        f"{attachment_headers}"
-        "------=_Part--\r\n"
-    ).encode()
+        mime_raw = (
+            'Content-Type: multipart/mixed; boundary="----=_Part"\r\n'
+            "\r\n"
+            "------=_Part\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Body text\r\n"
+            f"{attachment_headers}"
+            "------=_Part--\r\n"
+        ).encode()
 
     plist = (
         b'<?xml version="1.0" encoding="UTF-8"?>\n'
@@ -1068,6 +1075,221 @@ Content-Disposition: attachment; filename="doc.pdf"
         assert len(result) == 1
         assert result[0].filename == "doc.pdf"
         assert result[0].file_size > 0
+
+
+class TestMimePartNumbers:
+    """Tests for _mime_part_numbers helper."""
+
+    def test_flat_multipart(self):
+        """Top-level children get integer part numbers."""
+        import email as email_mod
+
+        raw = """\
+Content-Type: multipart/mixed; boundary="----=_B"
+
+------=_B
+Content-Type: text/plain
+
+Body
+
+------=_B
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="doc.pdf"
+
+------=_B--
+"""
+        msg = email_mod.message_from_string(raw)
+        nums = _mime_part_numbers(msg)
+        parts = list(msg.walk())
+        # parts[0] = multipart container (no entry)
+        # parts[1] = text/plain -> "1"
+        # parts[2] = application/pdf -> "2"
+        assert nums[id(parts[1])] == "1"
+        assert nums[id(parts[2])] == "2"
+
+    def test_nested_multipart(self):
+        """Nested children get dot-notation part numbers."""
+        import email as email_mod
+
+        raw = (
+            'Content-Type: multipart/mixed; boundary="outer"\r\n'
+            "\r\n"
+            "--outer\r\n"
+            'Content-Type: multipart/alternative; boundary="inner1"\r\n'
+            "\r\n"
+            "--inner1\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Body\r\n"
+            "--inner1\r\n"
+            "Content-Type: text/html\r\n"
+            "\r\n"
+            "<p>Body</p>\r\n"
+            "--inner1--\r\n"
+            "--outer\r\n"
+            'Content-Type: multipart/mixed; boundary="inner2"\r\n'
+            "\r\n"
+            "--inner2\r\n"
+            "Content-Type: text/html\r\n"
+            "\r\n"
+            "<p>Forwarded</p>\r\n"
+            "--inner2\r\n"
+            "Content-Type: application/pdf\r\n"
+            'Content-Disposition: attachment; filename="invoice.pdf"\r\n'
+            "\r\n"
+            "--inner2--\r\n"
+            "--outer--\r\n"
+        )
+        msg = email_mod.message_from_string(raw)
+        nums = _mime_part_numbers(msg)
+
+        # Walk order: outer, inner1, text/plain, text/html,
+        #             inner2, text/html, application/pdf
+        leaf_parts = [
+            p for p in msg.walk()
+            if not p.get_content_maintype() == "multipart"
+        ]
+        assert nums[id(leaf_parts[0])] == "1.1"  # text/plain
+        assert nums[id(leaf_parts[1])] == "1.2"  # text/html
+        assert nums[id(leaf_parts[2])] == "2.1"  # text/html (fwd)
+        assert nums[id(leaf_parts[3])] == "2.2"  # application/pdf
+
+
+class TestNestedExternalAttachments:
+    """External attachments in nested MIME structures.
+
+    Apple Mail uses dot-notation subdirectories (e.g. ``2.2/``)
+    for attachments nested inside multipart sub-parts. This
+    tests that both ``get_attachment_content`` and
+    ``_extract_attachments`` correctly locate these files.
+    """
+
+    @staticmethod
+    def _nested_mime() -> bytes:
+        """Build a nested multipart MIME (forwarded-style).
+
+        Structure::
+            multipart/mixed (outer)
+              multipart/alternative (part 1)
+                text/plain (part 1.1)
+                text/html  (part 1.2)
+              multipart/mixed (part 2)
+                text/html  (part 2.1 - forwarded body)
+                application/pdf (part 2.2 - the invoice)
+        """
+        return (
+            'Content-Type: multipart/mixed; boundary="outer"\r\n'
+            "\r\n"
+            "--outer\r\n"
+            'Content-Type: multipart/alternative; boundary="alt"\r\n'
+            "\r\n"
+            "--alt\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Body text\r\n"
+            "--alt\r\n"
+            "Content-Type: text/html\r\n"
+            "\r\n"
+            "<p>Body</p>\r\n"
+            "--alt--\r\n"
+            "--outer\r\n"
+            'Content-Type: multipart/mixed; boundary="fwd"\r\n'
+            "\r\n"
+            "--fwd\r\n"
+            "Content-Type: text/html\r\n"
+            "\r\n"
+            "<p>Forwarded body</p>\r\n"
+            "--fwd\r\n"
+            "Content-Type: application/pdf\r\n"
+            'Content-Disposition: attachment; filename="invoice.pdf"\r\n'
+            "\r\n"
+            "--fwd--\r\n"
+            "--outer--\r\n"
+        ).encode()
+
+    def test_get_attachment_content_nested(self, tmp_path: Path):
+        """get_attachment_content finds file in dotted subdir."""
+        pdf_bytes = b"%PDF-1.4 nested invoice data"
+        emlx = _build_partial_tree(
+            tmp_path,
+            filenames={"2.2": "invoice.pdf"},
+            file_content=pdf_bytes,
+            mime_raw=self._nested_mime(),
+        )
+
+        result = get_attachment_content(emlx, "invoice.pdf")
+        assert result is not None
+        data, mime_type = result
+        assert data == pdf_bytes
+        assert "pdf" in mime_type or "octet" in mime_type
+
+    def test_extract_attachments_nested_size(self, tmp_path: Path):
+        """_extract_attachments gets file size from dotted subdir."""
+        pdf_bytes = b"x" * 9876
+        emlx = _build_partial_tree(
+            tmp_path,
+            filenames={"2.2": "invoice.pdf"},
+            file_content=pdf_bytes,
+            mime_raw=self._nested_mime(),
+        )
+
+        result = parse_emlx(emlx)
+        assert result is not None
+        assert result.attachments is not None
+        assert len(result.attachments) == 1
+        assert result.attachments[0].filename == "invoice.pdf"
+        assert result.attachments[0].file_size == 9876
+
+    def test_flat_still_works(self, tmp_path: Path):
+        """Top-level attachment in subdir 2/ still works."""
+        img_bytes = b"\x89PNG flat attachment"
+        emlx = _build_partial_tree(
+            tmp_path,
+            filenames={2: "photo.jpeg"},
+            file_content=img_bytes,
+        )
+
+        result = get_attachment_content(emlx, "photo.jpeg")
+        assert result is not None
+        data, _ = result
+        assert data == img_bytes
+
+    def test_deeply_nested(self, tmp_path: Path):
+        """Three levels deep: subdir 1.2.1 works."""
+        mime_raw = (
+            'Content-Type: multipart/mixed; boundary="L1"\r\n'
+            "\r\n"
+            "--L1\r\n"
+            'Content-Type: multipart/mixed; boundary="L2"\r\n'
+            "\r\n"
+            "--L2\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Body\r\n"
+            "--L2\r\n"
+            'Content-Type: multipart/mixed; boundary="L3"\r\n'
+            "\r\n"
+            "--L3\r\n"
+            "Content-Type: application/pdf\r\n"
+            'Content-Disposition: attachment; filename="deep.pdf"\r\n'
+            "\r\n"
+            "--L3--\r\n"
+            "--L2--\r\n"
+            "--L1--\r\n"
+        ).encode()
+
+        pdf_bytes = b"%PDF deeply nested"
+        emlx = _build_partial_tree(
+            tmp_path,
+            filenames={"1.2.1": "deep.pdf"},
+            file_content=pdf_bytes,
+            mime_raw=mime_raw,
+        )
+
+        result = get_attachment_content(emlx, "deep.pdf")
+        assert result is not None
+        data, mime_type = result
+        assert data == pdf_bytes
 
 
 class TestDetectMailVersion:


### PR DESCRIPTION
## Summary

- Apple Mail uses dot-notation subdirectories (e.g. `Attachments/<id>/2.2/`) for attachments nested inside multipart sub-parts. This is common in forwarded emails where the MIME structure is `multipart/mixed > multipart/mixed > application/pdf`.
- `_find_external_attachment()` constructed only flat integer subdirectory names (e.g. `2/`), so extraction failed with "Attachment not found" and `size: 0` for any nested attachment.
- Added `_mime_part_numbers()` helper that computes RFC-style dotted part numbers (`"1"`, `"2"`, `"2.2"`, `"1.2.1"`) by recursively walking the MIME tree. These directly correspond to Apple Mail's `Attachments/` subdirectory naming.
- Updated `_extract_attachments()`, `get_attachment_content()`, and `_read_external_attachment()` to use actual MIME part numbers instead of the flat counter.

## Test plan

- [x] 6 new tests: `TestMimePartNumbers` (flat + nested), `TestNestedExternalAttachments` (nested content extraction, nested size estimation, flat regression, deeply nested 3-level)
- [x] All 66 existing `test_disk.py` tests pass (no regressions)
- [x] Full suite: 361 passed
- [x] Manual verification: 3 real forwarded `.partial.emlx` emails that previously failed now extract correctly