### PR TITLE
Release 0.3.3: cache perms + part-number hardening + CI Node 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-05-14
+
 ### Fixed
 
 - **External-attachment lookup for nested MIME parts** — Apple Mail stores externally-referenced attachments under `Attachments/<msg_id>/<part>/` where `<part>` is an RFC-style MIME part number. Top-level parts use flat integers (`2/`), but nested parts (common in forwarded emails: `multipart/mixed > multipart/mixed > application/pdf`) use dot notation (`2.2/`, `1.16/`, etc.). The previous implementation tracked a flat attachment counter and routed every lookup to a top-level subdir, so any nested attachment came back as `size: 0` from `parse_emlx()` and `None` from `get_attachment_content()`. New `_mime_part_numbers()` helper walks the MIME tree and builds an `id(part) → "2.2"` map; `_extract_attachments()`, `get_attachment_content()`, and `_find_external_attachment()` now use real part numbers instead of the flat counter. Scoped check against a real ~72K-message mailbox: 4,063 dot-notation subdirs (~18% of all attachments) were affected; flat-attachment behavior is preserved (regression test included). Thanks to @scottwb for the fix and tests. (#85)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apple-mail-mcp"
-version = "0.3.2"
+version = "0.3.3"
 description = "Apple Mail MCP server with full-coverage FTS5 body search. Reliable on large mailboxes where AppleScript-based servers timeout."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/imdinu/apple-mail-mcp",
     "source": "github"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "apple-mail-mcp",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "apple-mail-mcp"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Version bump for **0.3.3** — preps the release tag.

This PR contains **only the version-bump and CHANGELOG rename**. The actual fixes for 0.3.3 already landed on `main` via #85 (@scottwb's nested-attachment fix) and #87 (the patch bundle: cache perms, part-number hardening, CI Node 24 opt-in).

### Files changed

- `pyproject.toml` → `version = "0.3.3"`
- `server.json` → root `"version": "0.3.3"` and `packages[0].version`
- `uv.lock` → resynced via `uv build` (1-line project-self-reference update)
- `CHANGELOG.md` → renamed `## [Unreleased]` → `## [0.3.3] - 2026-05-14`; added a fresh empty `## [Unreleased]` heading above for the next cycle

### What ships in 0.3.3

| Type | Change | Reference |
|---|---|---|
| Fix | External-attachment lookup for nested MIME parts (dot-notation `Attachments/<id>/2.2/` subdirs) | #85, @scottwb |
| Fix | `_mime_part_numbers` consumer hardening (skip on missing part-number instead of misrouting) | #87 |
| Security | Attachment cache files chmod'd to `0o600` (matches index DB posture) | #79 |
| Changed | CI workflows opt into Node 24 ahead of GitHub's June 2026 cutover | #87 |

## Release sequence after this merges

1. Merge this PR (squash) → `main` is at v0.3.3
2. `git pull origin main`
3. `git tag v0.3.3 && git push origin v0.3.3`
4. `release.yml` fires automatically → `uv build` → PyPI publish → GitHub Release

## Test plan

- [x] All version strings consistent (`pyproject.toml`, `server.json` ×2, `uv.lock`) at `0.3.3`
- [x] CHANGELOG heading correctly renamed; fresh `[Unreleased]` left in place
- [x] `ruff check src/` and `ruff format --check src/` clean
- [x] **364/364 tests pass**
- [x] No source/test files touched — diff is metadata only
