### PR TITLE
Add account exclusion for disk index privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Tested against [8 other Apple Mail MCP servers](https://imdinu.github.io/apple-m
 | `APPLE_MAIL_DEFAULT_MAILBOX` | `INBOX` | Default mailbox |
 | `APPLE_MAIL_INDEX_PATH` | `~/.apple-mail-mcp/index.db` | Index location |
 | `APPLE_MAIL_INDEX_MAX_EMAILS` | _unset_ | Optional per-mailbox ceiling (default: uncapped) |
-| `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Mailboxes to skip in search |
+| `APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS` | _unset_ | Account names or UUIDs to skip during indexing |
+| `APPLE_MAIL_INDEX_INCLUDE_MAILBOXES` | _unset_ | Optional mailbox allow-list for indexing |
+| `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Mailboxes to skip during indexing |
 | `APPLE_MAIL_READ_ONLY` | `false` | Disable write operations |
 
 ```json
@@ -82,12 +84,17 @@ Tested against [8 other Apple Mail MCP servers](https://imdinu.github.io/apple-m
       "command": "apple-mail-mcp",
       "args": ["--watch"],
       "env": {
-        "APPLE_MAIL_DEFAULT_ACCOUNT": "Work"
+        "APPLE_MAIL_DEFAULT_ACCOUNT": "iCloud",
+        "APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS": "Work"
       }
     }
   }
 }
 ```
+
+`APPLE_MAIL_DEFAULT_ACCOUNT` only chooses the default live Mail account for
+tools. To keep an account out of full-text search, use
+`APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS` and rebuild the index.
 
 ## CLI Usage
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,9 @@ Apple Mail MCP is configured via environment variables. All settings have sensib
 | `APPLE_MAIL_INDEX_PATH` | `~/.apple-mail-mcp/index.db` | SQLite index database location |
 | `APPLE_MAIL_INDEX_MAX_EMAILS` | _unset_ | Optional per-mailbox ceiling (default: uncapped) |
 | `APPLE_MAIL_INDEX_STALENESS_HOURS` | `24` | Hours before index is considered stale |
-| `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Comma-separated mailboxes to skip in search |
+| `APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS` | _unset_ | Comma-separated account names or UUIDs to skip during indexing |
+| `APPLE_MAIL_INDEX_INCLUDE_MAILBOXES` | _unset_ | Optional comma-separated mailbox allow-list for indexing |
+| `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` | `Drafts` | Comma-separated mailboxes to skip during indexing |
 | `APPLE_MAIL_READ_ONLY` | `false` | When `true`, disables any write operations |
 
 ### Per-Mailbox Email Limit (Optional)
@@ -24,6 +26,29 @@ apple-mail-mcp rebuild
 ```
 
 When a cap is set and a mailbox exceeds it, the most recent emails by file modification time are kept. `apple-mail-mcp rebuild` reports how many mailboxes hit the cap, and `apple-mail-mcp status` surfaces the same information after the fact.
+
+### Index Scope and Privacy
+
+`APPLE_MAIL_DEFAULT_ACCOUNT` is only a default for live Mail tools. It does not
+prevent other accounts from being indexed. Use index-scope variables when an
+account or mailbox must stay out of full-text search:
+
+```bash
+export APPLE_MAIL_DEFAULT_ACCOUNT=iCloud
+export APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS=Work
+export APPLE_MAIL_INDEX_INCLUDE_MAILBOXES=INBOX,Archive
+apple-mail-mcp rebuild
+```
+
+`APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS` accepts account UUIDs or friendly account
+names. UUIDs match Mail's on-disk account directories directly. Friendly names
+are resolved through Mail's account metadata before any `.emlx` content is
+parsed; if a friendly name cannot be resolved, indexing fails closed and asks
+you to use a UUID from `apple-mail-mcp accounts`.
+
+`APPLE_MAIL_INDEX_INCLUDE_MAILBOXES` is an allow-list: when set, only those
+mailboxes are indexed. `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` is still applied,
+so an excluded mailbox wins if it appears in both lists.
 
 ## MCP Client Configuration
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -166,6 +166,12 @@ Every time the server starts, it runs a fast **state reconciliation** against th
 
 This takes **<5s** even for 20,000+ emails (vs. 60s+ timeout with the old JXA-based sync).
 
+The sync honors index-scope configuration on every run. Accounts listed in
+`APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS` and mailboxes outside
+`APPLE_MAIL_INDEX_INCLUDE_MAILBOXES` are omitted from the disk inventory; if
+they were indexed before the configuration changed, sync removes those rows
+from the SQLite index.
+
 ## Real-Time Updates
 
 Enable automatic index updates with the `--watch` flag:
@@ -179,6 +185,9 @@ The file watcher monitors `~/Library/Mail/V10/` for:
 - New `.emlx` files → parse and insert into index
 - Deleted `.emlx` files → remove from index
 - Moved `.emlx` files → update path in index
+
+Watcher events for excluded accounts or non-included mailboxes are ignored
+before the file is parsed.
 
 ## Date-Range Filtering
 
@@ -245,4 +254,3 @@ Pagination works with all scopes, date filters, and highlighting.
 | Startup sync | 60s timeout | <5s | **12x** |
 | Initial build | — | ~1–2 min | One-time |
 | Disk usage | — | ~6 KB/email | — |
-

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,7 +35,21 @@ Common issues and their solutions.
 
 3. **Index is stale.** Check with `apple-mail-mcp status`. If the index is old, run `apple-mail-mcp rebuild` or start the server with `--watch` for real-time updates.
 
-4. **Mailbox excluded.** By default, `Drafts` is excluded from search. Check `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` in your configuration.
+4. **Index scope excludes it.** By default, `Drafts` is excluded from the index. Also check `APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS`, `APPLE_MAIL_INDEX_INCLUDE_MAILBOXES`, and `APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES` in your configuration.
+
+## Account Exclusion Fails During Indexing
+
+**Symptom:** `apple-mail-mcp index` or `apple-mail-mcp rebuild` reports that it
+could not resolve `APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS`.
+
+**Cause:** Friendly account names must be resolved to Mail's on-disk account
+UUIDs before indexing starts. If Mail account metadata is unavailable, the
+indexer fails closed instead of risking indexing an account you meant to
+exclude.
+
+**Fix:** Run `apple-mail-mcp accounts` and set
+`APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS` to the account UUID, or make sure Mail's
+account metadata is available in the environment where you run the indexer.
 
 ## Startup Timeout (v0.1.5 and earlier)
 

--- a/src/apple_mail_mcp/config.py
+++ b/src/apple_mail_mcp/config.py
@@ -36,6 +36,14 @@ def get_default_mailbox() -> str:
 # ========== Index Configuration ==========
 
 
+def _parse_csv_env(name: str) -> set[str]:
+    """Parse a comma-separated environment variable into non-empty values."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return set()
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
 def get_index_path() -> Path:
     """
     Get the FTS5 index database path.
@@ -82,6 +90,35 @@ def get_index_exclude_mailboxes() -> set[str]:
     if env_val is not None:
         return {m.strip() for m in env_val.split(",") if m.strip()}
     return {"Drafts"}
+
+
+def get_index_include_mailboxes() -> set[str] | None:
+    """
+    Get the mailbox allow-list for indexing.
+
+    Set APPLE_MAIL_INDEX_INCLUDE_MAILBOXES to a comma-separated list of
+    mailbox names. When unset, all non-excluded mailboxes are indexed.
+
+    Returns:
+        Set of mailbox names to include, or None to include all.
+    """
+    values = _parse_csv_env("APPLE_MAIL_INDEX_INCLUDE_MAILBOXES")
+    return values or None
+
+
+def get_index_exclude_accounts() -> set[str]:
+    """
+    Get accounts to exclude from indexing.
+
+    Set APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS to a comma-separated list of
+    account names or account UUIDs. UUIDs are matched directly against
+    Mail.app account directory names; friendly names are resolved when
+    Apple Mail account metadata is available.
+
+    Returns:
+        Set of account names or UUIDs to exclude.
+    """
+    return _parse_csv_env("APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS")
 
 
 def get_index_staleness_hours() -> float:

--- a/src/apple_mail_mcp/index/disk.py
+++ b/src/apple_mail_mcp/index/disk.py
@@ -38,6 +38,11 @@ from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
+_ACCOUNT_UUID_RE = re.compile(
+    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -47,6 +52,10 @@ MAIL_VERSION = "V10"
 
 # Cached result of find_mail_directory()
 _cached_mail_dir: Path | None = None
+
+
+class AccountFilterResolutionError(RuntimeError):
+    """Raised when an account exclusion cannot be resolved safely."""
 
 
 def _detect_mail_version() -> str:
@@ -202,7 +211,13 @@ def find_envelope_index(mail_dir: Path) -> Path:
     return envelope_path
 
 
-def read_envelope_index(mail_dir: Path) -> dict[int, dict]:
+def read_envelope_index(
+    mail_dir: Path,
+    *,
+    exclude_accounts: set[str] | None = None,
+    include_mailboxes: set[str] | None = None,
+    exclude_mailboxes: set[str] | None = None,
+) -> dict[int, dict]:
     """
     Read the Envelope Index database to get message metadata.
 
@@ -247,6 +262,11 @@ def read_envelope_index(mail_dir: Path) -> dict[int, dict]:
             ORDER BY m.date_received DESC
         """)
 
+        resolved_exclude_accounts = resolve_account_filter_tokens(
+            mail_dir,
+            exclude_accounts or set(),
+        )
+
         for row in cursor:
             msg_id = row["id"]
 
@@ -254,6 +274,15 @@ def read_envelope_index(mail_dir: Path) -> dict[int, dict]:
             # Format: mailbox://[account-uuid]/[mailbox-name]
             mailbox_url = row["mailbox_url"] or ""
             account, mailbox = _parse_mailbox_url(mailbox_url)
+
+            if not should_index_account(account, resolved_exclude_accounts):
+                continue
+            if not should_index_mailbox(
+                mailbox,
+                include_mailboxes=include_mailboxes,
+                exclude_mailboxes=exclude_mailboxes,
+            ):
+                continue
 
             result[msg_id] = {
                 "account": account,
@@ -1030,9 +1059,131 @@ def _extract_links_from_message(
     return links
 
 
+def _filter_key(value: str) -> str:
+    """Normalize names for user-facing filter comparisons."""
+    return value.strip().casefold()
+
+
+def _matches_filter(value: str, filters: set[str] | None) -> bool:
+    """Return whether value matches a configured filter, case-insensitively."""
+    if not filters:
+        return False
+    value_key = _filter_key(value)
+    return any(_filter_key(item) == value_key for item in filters)
+
+
+def should_index_account(
+    account: str,
+    exclude_accounts: set[str] | None,
+) -> bool:
+    """Return whether an account should be indexed."""
+    return not _matches_filter(account, exclude_accounts)
+
+
+def should_index_mailbox(
+    mailbox: str,
+    *,
+    include_mailboxes: set[str] | None,
+    exclude_mailboxes: set[str] | None,
+) -> bool:
+    """Return whether a mailbox should be indexed."""
+    if include_mailboxes and not _matches_filter(mailbox, include_mailboxes):
+        return False
+    return not _matches_filter(mailbox, exclude_mailboxes)
+
+
+def _mail_account_dir_names(mail_dir: Path) -> set[str]:
+    """Return account directory names under the Mail version directory."""
+    try:
+        return {
+            entry.name
+            for entry in mail_dir.iterdir()
+            if entry.is_dir() and entry.name != "MailData"
+        }
+    except OSError:
+        return set()
+
+
+def _looks_like_account_uuid(value: str) -> bool:
+    """Return whether a configured value looks like a Mail account UUID."""
+    return bool(_ACCOUNT_UUID_RE.fullmatch(value.strip()))
+
+
+def resolve_account_filter_tokens(
+    mail_dir: Path,
+    account_filters: set[str],
+) -> set[str]:
+    """
+    Expand configured account filters with known account UUIDs.
+
+    Mail.app stores messages under UUID-like account directories. Users tend
+    to configure friendly account names, so when a filter does not already
+    match an on-disk account directory we ask Apple Mail for its account map.
+    If that lookup is unavailable, fail closed to avoid indexing a configured
+    account exclusion by accident.
+    """
+    if not account_filters:
+        return set()
+
+    resolved = set(account_filters)
+    account_dirs = _mail_account_dir_names(mail_dir)
+    unresolved = {
+        value
+        for value in account_filters
+        if not _matches_filter(value, account_dirs)
+        and not _looks_like_account_uuid(value)
+    }
+    if not unresolved:
+        return resolved
+
+    try:
+        from ..builders import AccountsQueryBuilder
+        from ..executor import execute_with_core
+        from .accounts import AccountMap
+
+        accounts = execute_with_core(
+            AccountsQueryBuilder().list_accounts(),
+            timeout=15,
+        )
+        AccountMap.get_instance().load_from_jxa(accounts)
+    except Exception as e:
+        values = ", ".join(sorted(unresolved))
+        raise AccountFilterResolutionError(
+            "Could not resolve APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS value(s): "
+            f"{values}. Use account UUIDs from `apple-mail-mcp accounts`, "
+            "or ensure Apple Mail account metadata is available."
+        ) from e
+
+    matched_filters: set[str] = set()
+    for account in accounts:
+        name = account.get("name", "")
+        uid = account.get("id", "")
+        if not name or not uid:
+            continue
+        for value in unresolved:
+            if _matches_filter(name, {value}) or _matches_filter(uid, {value}):
+                resolved.add(name)
+                resolved.add(uid)
+                matched_filters.add(value)
+
+    missing = unresolved - matched_filters
+    if missing:
+        values = ", ".join(sorted(missing))
+        raise AccountFilterResolutionError(
+            "Could not resolve APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS value(s): "
+            f"{values}. Use account UUIDs from `apple-mail-mcp accounts`, "
+            "or check the configured account name."
+        )
+
+    return resolved
+
+
 def scan_emlx_files(
     mail_dir: Path,
     exclude_mailboxes: set[str] | None = None,
+    *,
+    include_mailboxes: set[str] | None = None,
+    exclude_accounts: set[str] | None = None,
 ) -> Iterator[Path]:
     """
     Find all .emlx files in the Mail directory.
@@ -1041,6 +1192,10 @@ def scan_emlx_files(
         mail_dir: Path to ~/Library/Mail/V10/
         exclude_mailboxes: Mailbox names to skip (e.g. {"Drafts"}).
             Uses APPLE_MAIL_INDEX_EXCLUDE_MAILBOXES config if None.
+        include_mailboxes: Optional mailbox allow-list.
+            Uses APPLE_MAIL_INDEX_INCLUDE_MAILBOXES config if None.
+        exclude_accounts: Account names or UUIDs to skip.
+            Uses APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS config if None.
 
     Yields:
         Paths to .emlx files
@@ -1049,19 +1204,31 @@ def scan_emlx_files(
         from ..config import get_index_exclude_mailboxes
 
         exclude_mailboxes = get_index_exclude_mailboxes()
+    if include_mailboxes is None:
+        from ..config import get_index_include_mailboxes
+
+        include_mailboxes = get_index_include_mailboxes()
+    if exclude_accounts is None:
+        from ..config import get_index_exclude_accounts
+
+        exclude_accounts = get_index_exclude_accounts()
+
+    exclude_accounts = resolve_account_filter_tokens(
+        mail_dir,
+        exclude_accounts,
+    )
 
     # .emlx files are in: account-uuid/mailbox.mbox/Data/x/y/Messages/
     for emlx_path in mail_dir.rglob("*.emlx"):
-        # Skip excluded mailboxes by checking .mbox dir name
-        if exclude_mailboxes:
-            parts = emlx_path.relative_to(mail_dir).parts
-            if len(parts) > 1:
-                mbox_dir = parts[1]
-                mbox_name = (
-                    mbox_dir[:-5] if mbox_dir.endswith(".mbox") else mbox_dir
-                )
-                if mbox_name in exclude_mailboxes:
-                    continue
+        account, mailbox = _infer_account_mailbox(emlx_path, mail_dir)
+        if not should_index_account(account, exclude_accounts):
+            continue
+        if not should_index_mailbox(
+            mailbox,
+            include_mailboxes=include_mailboxes,
+            exclude_mailboxes=exclude_mailboxes,
+        ):
+            continue
 
         yield emlx_path
 
@@ -1080,14 +1247,37 @@ def scan_all_emails(mail_dir: Path) -> Iterator[dict]:
         Email dicts with: id, account, mailbox, subject, sender,
         content, date_received, emlx_path
     """
+    from ..config import (
+        get_index_exclude_accounts,
+        get_index_exclude_mailboxes,
+        get_index_include_mailboxes,
+    )
+
+    exclude_accounts = resolve_account_filter_tokens(
+        mail_dir,
+        get_index_exclude_accounts(),
+    )
+    exclude_mailboxes = get_index_exclude_mailboxes()
+    include_mailboxes = get_index_include_mailboxes()
+
     # First, try to read metadata from Envelope Index
     try:
-        metadata = read_envelope_index(mail_dir)
+        metadata = read_envelope_index(
+            mail_dir,
+            exclude_accounts=exclude_accounts,
+            include_mailboxes=include_mailboxes,
+            exclude_mailboxes=exclude_mailboxes,
+        )
     except (FileNotFoundError, sqlite3.Error):
         metadata = {}
 
     # Scan .emlx files and combine with metadata
-    for emlx_path in scan_emlx_files(mail_dir):
+    for emlx_path in scan_emlx_files(
+        mail_dir,
+        exclude_mailboxes=exclude_mailboxes,
+        include_mailboxes=include_mailboxes,
+        exclude_accounts=exclude_accounts,
+    ):
         try:
             parsed = parse_emlx(emlx_path)
         except Exception as e:
@@ -1121,6 +1311,10 @@ def scan_all_emails(mail_dir: Path) -> Iterator[dict]:
 
 def iter_disk_inventory(
     mail_dir: Path,
+    *,
+    exclude_mailboxes: set[str] | None = None,
+    include_mailboxes: set[str] | None = None,
+    exclude_accounts: set[str] | None = None,
 ) -> Iterator[tuple[str, str, int, str]]:
     """Stream the disk inventory as `(account, mailbox, msg_id, path)` tuples.
 
@@ -1131,7 +1325,12 @@ def iter_disk_inventory(
     Yields tuples instead of building a full dict. Files with non-numeric
     or unparseable names are skipped silently.
     """
-    for emlx_path in scan_emlx_files(mail_dir):
+    for emlx_path in scan_emlx_files(
+        mail_dir,
+        exclude_mailboxes=exclude_mailboxes,
+        include_mailboxes=include_mailboxes,
+        exclude_accounts=exclude_accounts,
+    ):
         try:
             msg_id = extract_message_id(emlx_path)
             account, mailbox = _infer_account_mailbox(emlx_path, mail_dir)
@@ -1140,7 +1339,13 @@ def iter_disk_inventory(
         yield (account, mailbox, msg_id, str(emlx_path))
 
 
-def get_disk_inventory(mail_dir: Path) -> dict[tuple[str, str, int], str]:
+def get_disk_inventory(
+    mail_dir: Path,
+    *,
+    exclude_mailboxes: set[str] | None = None,
+    include_mailboxes: set[str] | None = None,
+    exclude_accounts: set[str] | None = None,
+) -> dict[tuple[str, str, int], str]:
     """
     Fast inventory of all emails on disk WITHOUT parsing content.
 
@@ -1153,13 +1358,21 @@ def get_disk_inventory(mail_dir: Path) -> dict[tuple[str, str, int], str]:
 
     Args:
         mail_dir: Path to ~/Library/Mail/V10/
+        exclude_mailboxes: Optional mailbox deny-list.
+        include_mailboxes: Optional mailbox allow-list.
+        exclude_accounts: Optional account name/UUID deny-list.
 
     Returns:
         Dict mapping (account, mailbox, msg_id) -> emlx_path string
     """
     return {
         (account, mailbox, msg_id): path
-        for account, mailbox, msg_id, path in iter_disk_inventory(mail_dir)
+        for account, mailbox, msg_id, path in iter_disk_inventory(
+            mail_dir,
+            exclude_mailboxes=exclude_mailboxes,
+            include_mailboxes=include_mailboxes,
+            exclude_accounts=exclude_accounts,
+        )
     }
 
 

--- a/src/apple_mail_mcp/index/watcher.py
+++ b/src/apple_mail_mcp/index/watcher.py
@@ -20,6 +20,11 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ..config import (
+    get_index_exclude_accounts,
+    get_index_exclude_mailboxes,
+    get_index_include_mailboxes,
+)
 from .disk import find_mail_directory, parse_emlx
 from .schema import (
     CLEAR_PARSE_FAILURE_SQL,
@@ -79,6 +84,9 @@ class IndexWatcher:
         self.debounce_ms = debounce_ms
 
         self._mail_dir: Path | None = None
+        self._exclude_accounts = get_index_exclude_accounts()
+        self._exclude_mailboxes = get_index_exclude_mailboxes()
+        self._include_mailboxes = get_index_include_mailboxes()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -106,6 +114,13 @@ class IndexWatcher:
         except FileNotFoundError:
             logger.warning("Mail directory not found, watcher not started")
             return False
+
+        from .disk import resolve_account_filter_tokens
+
+        self._exclude_accounts = resolve_account_filter_tokens(
+            self._mail_dir,
+            self._exclude_accounts,
+        )
 
         self._stop_event.clear()
         self._thread = threading.Thread(
@@ -238,6 +253,17 @@ class IndexWatcher:
         # Use UUID as account name (more reliable than trying to map)
         account_name = account_uuid
         mailbox_name = mailbox_dir
+
+        from .disk import should_index_account, should_index_mailbox
+
+        if not should_index_account(account_name, self._exclude_accounts):
+            return None
+        if not should_index_mailbox(
+            mailbox_name,
+            include_mailboxes=self._include_mailboxes,
+            exclude_mailboxes=self._exclude_mailboxes,
+        ):
+            return None
 
         return account_name, mailbox_name, message_id
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for environment-based configuration helpers."""
+
+from __future__ import annotations
+
+from apple_mail_mcp.config import (
+    get_index_exclude_accounts,
+    get_index_include_mailboxes,
+)
+
+
+def test_get_index_exclude_accounts_parses_csv(monkeypatch):
+    monkeypatch.setenv(
+        "APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS",
+        "Extreme, work-uuid ,, iCloud",
+    )
+
+    assert get_index_exclude_accounts() == {
+        "Extreme",
+        "work-uuid",
+        "iCloud",
+    }
+
+
+def test_get_index_include_mailboxes_parses_csv(monkeypatch):
+    monkeypatch.setenv(
+        "APPLE_MAIL_INDEX_INCLUDE_MAILBOXES",
+        "INBOX, Yoshiko/Cubo ,, Remodel",
+    )
+
+    assert get_index_include_mailboxes() == {
+        "INBOX",
+        "Yoshiko/Cubo",
+        "Remodel",
+    }
+
+
+def test_get_index_include_mailboxes_defaults_to_none(monkeypatch):
+    monkeypatch.delenv("APPLE_MAIL_INDEX_INCLUDE_MAILBOXES", raising=False)
+
+    assert get_index_include_mailboxes() is None

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from apple_mail_mcp.index.disk import (
     MAX_EMLX_SIZE,
@@ -371,6 +374,113 @@ class TestScanExcludesDrafts:
         # With empty exclusion set
         files = list(scan_emlx_files(mail_dir, exclude_mailboxes=set()))
         assert len(files) == 2
+
+
+class TestScanIndexFilters:
+    """Tests for account and mailbox filters during disk scanning."""
+
+    def test_scan_excludes_configured_accounts(self, tmp_path: Path):
+        from apple_mail_mcp.index.disk import scan_emlx_files
+
+        mail_dir = tmp_path / "V10"
+        personal = mail_dir / "personal-uuid" / "INBOX.mbox" / "Data"
+        work = mail_dir / "work-uuid" / "INBOX.mbox" / "Data"
+        personal.mkdir(parents=True)
+        work.mkdir(parents=True)
+
+        (personal / "1.emlx").write_bytes(b"test")
+        (work / "2.emlx").write_bytes(b"test")
+
+        files = list(
+            scan_emlx_files(
+                mail_dir,
+                exclude_mailboxes=set(),
+                exclude_accounts={"work-uuid"},
+            )
+        )
+
+        assert len(files) == 1
+        assert "personal-uuid" in str(files[0])
+
+    def test_scan_honors_mailbox_allow_list(self, tmp_path: Path):
+        from apple_mail_mcp.index.disk import scan_emlx_files
+
+        mail_dir = tmp_path / "V10"
+        inbox = mail_dir / "acc" / "INBOX.mbox" / "Data"
+        archive = mail_dir / "acc" / "Archive.mbox" / "Data"
+        inbox.mkdir(parents=True)
+        archive.mkdir(parents=True)
+
+        (inbox / "1.emlx").write_bytes(b"test")
+        (archive / "2.emlx").write_bytes(b"test")
+
+        files = list(
+            scan_emlx_files(
+                mail_dir,
+                exclude_mailboxes=set(),
+                include_mailboxes={"INBOX"},
+            )
+        )
+
+        assert len(files) == 1
+        assert "INBOX" in str(files[0])
+
+    @patch("apple_mail_mcp.executor.execute_with_core")
+    def test_scan_resolves_friendly_account_names(
+        self,
+        mock_execute,
+        tmp_path: Path,
+    ):
+        from apple_mail_mcp.index.disk import scan_emlx_files
+
+        mock_execute.return_value = [
+            {"name": "Extreme", "id": "work-uuid"},
+            {"name": "Personal", "id": "personal-uuid"},
+        ]
+
+        mail_dir = tmp_path / "V10"
+        personal = mail_dir / "personal-uuid" / "INBOX.mbox" / "Data"
+        work = mail_dir / "work-uuid" / "INBOX.mbox" / "Data"
+        personal.mkdir(parents=True)
+        work.mkdir(parents=True)
+
+        (personal / "1.emlx").write_bytes(b"test")
+        (work / "2.emlx").write_bytes(b"test")
+
+        files = list(
+            scan_emlx_files(
+                mail_dir,
+                exclude_mailboxes=set(),
+                exclude_accounts={"Extreme"},
+            )
+        )
+
+        assert len(files) == 1
+        assert "personal-uuid" in str(files[0])
+
+    @patch("apple_mail_mcp.executor.execute_with_core")
+    def test_unresolved_account_names_fail_closed(
+        self,
+        mock_execute,
+        tmp_path: Path,
+    ):
+        from apple_mail_mcp.index.disk import scan_emlx_files
+
+        mock_execute.side_effect = RuntimeError("Mail unavailable")
+
+        mail_dir = tmp_path / "V10"
+        inbox = mail_dir / "work-uuid" / "INBOX.mbox" / "Data"
+        inbox.mkdir(parents=True)
+        (inbox / "1.emlx").write_bytes(b"test")
+
+        with pytest.raises(RuntimeError, match="APPLE_MAIL_INDEX_EXCLUDE"):
+            list(
+                scan_emlx_files(
+                    mail_dir,
+                    exclude_mailboxes=set(),
+                    exclude_accounts={"Extreme"},
+                )
+            )
 
 
 class TestExtractAttachments:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -228,6 +228,64 @@ class TestSyncFromDisk:
         cursor = sync_db.execute("SELECT COUNT(*) FROM emails")
         assert cursor.fetchone()[0] == 0
 
+    def test_sync_removes_rows_for_excluded_accounts(
+        self,
+        sync_db: sqlite3.Connection,
+        mail_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Changing account exclusions should purge old indexed rows."""
+        self._create_emlx(mail_dir, "personal-uuid", "INBOX", 1001)
+        self._create_emlx(mail_dir, "work-uuid", "INBOX", 2001)
+
+        sync_db.execute(
+            """INSERT INTO emails
+               (message_id, account, mailbox, subject, emlx_path)
+               VALUES (2001, 'work-uuid', 'INBOX', 'Private work mail',
+                       '/old/work/2001.emlx')"""
+        )
+        sync_db.commit()
+
+        monkeypatch.setenv("APPLE_MAIL_INDEX_EXCLUDE_ACCOUNTS", "work-uuid")
+        result = sync_from_disk(sync_db, mail_dir)
+
+        assert result.added == 1
+        assert result.deleted == 1
+
+        rows = sync_db.execute(
+            "SELECT account FROM emails ORDER BY account"
+        ).fetchall()
+        assert [row["account"] for row in rows] == ["personal-uuid"]
+
+    def test_sync_removes_rows_outside_included_mailboxes(
+        self,
+        sync_db: sqlite3.Connection,
+        mail_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Changing mailbox allow-list should purge old indexed rows."""
+        self._create_emlx(mail_dir, "acc1", "INBOX", 1001)
+        self._create_emlx(mail_dir, "acc1", "Archive", 2001)
+
+        sync_db.execute(
+            """INSERT INTO emails
+               (message_id, account, mailbox, subject, emlx_path)
+               VALUES (2001, 'acc1', 'Archive', 'Old archive',
+                       '/old/archive/2001.emlx')"""
+        )
+        sync_db.commit()
+
+        monkeypatch.setenv("APPLE_MAIL_INDEX_INCLUDE_MAILBOXES", "INBOX")
+        result = sync_from_disk(sync_db, mail_dir)
+
+        assert result.added == 1
+        assert result.deleted == 1
+
+        rows = sync_db.execute(
+            "SELECT mailbox FROM emails ORDER BY mailbox"
+        ).fetchall()
+        assert [row["mailbox"] for row in rows] == ["INBOX"]
+
     def test_sync_detects_moved_emails(
         self, sync_db: sqlite3.Connection, mail_dir: Path
     ):

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -220,6 +220,20 @@ class TestPathParsing:
         )
         assert m is not None
 
+    def test_parse_path_ignores_excluded_account(self, tmp_path: Path):
+        """Excluded accounts should never be queued by the watcher."""
+        watcher = IndexWatcher(tmp_path / "watcher.db")
+        watcher._exclude_accounts = {"work-uuid"}
+
+        parsed = watcher._parse_path(
+            Path(
+                "/Users/x/Library/Mail/V10/work-uuid"
+                "/INBOX.mbox/Data/1/Messages/789.emlx"
+            )
+        )
+
+        assert parsed is None
+
 
 class TestPendingLimits:
     """Watcher should enforce memory safety limits."""


### PR DESCRIPTION
Adds index-scope controls for excluding accounts entirely from disk indexing and optionally allow-listing mailboxes. This keeps APPLE_MAIL_DEFAULT_ACCOUNT separate from privacy/security indexing boundaries. Validated with pytest and source lint.