### PR TITLE
Benchmarks: refresh competitor slate + introduce "Also noted" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ apple-mail-mcp index --verbose
 
 ## Performance
 
-Tested against [8 other Apple Mail MCP servers](https://imdinu.github.io/apple-mail-mcp/benchmarks/) on a real **~72K-message** mailbox:
+Tested against [7 other Apple Mail MCP servers](https://imdinu.github.io/apple-mail-mcp/benchmarks/) on a real **~72K-message** mailbox:
 
 - **Only server with full-coverage body search.** Most competitors don't support body search at all; the one that does (BastianZim) live-scans only the 5000 most recent messages — silent miss on anything older. Our FTS5 index covers the entire mailbox.
 - **~3ms single email fetch** via disk-first `.emlx` reading (no JXA round-trip).

--- a/benchmarks/charts.py
+++ b/benchmarks/charts.py
@@ -182,24 +182,26 @@ COMPETITOR_LABELS = {
     "imdinu": "apple-mail-mcp (ours)",
     "bastianzim": "BastianZim",
     "rusty": "rusty (Rust)",
+    "pl-lyfx": "pl-lyfx",
     "patrickfreyer": "patrickfreyer",
     "sweetrb": "sweetrb",
-    "dhravya": "dhravya (archived)",
+    "titouancreach": "titouancreach (Haskell)",
     "smorgan": "s-morgan-jeffries",
-    "attilagyorffy": "attilagyorffy (Go)",
-    "che-apple-mail": "che (Swift)",
 }
 
-# Display order: us first, then by interest
+# Display order: us first, then roughly fast → slow.
+# Envelope-Index-direct readers (bastianzim, rusty, pl-lyfx) cluster
+# at the top since they bypass AppleScript. AppleScript-backed
+# competitors trail.
 COMPETITOR_ORDER = [
     "imdinu",
     "bastianzim",
     "rusty",
+    "pl-lyfx",
     "patrickfreyer",
     "sweetrb",
-    "attilagyorffy",
+    "titouancreach",
     "smorgan",
-    "dhravya",
 ]
 
 # Per-scenario overrides: classify a (competitor, scenario) cell with a
@@ -218,8 +220,13 @@ SCENARIO_OVERRIDES: dict[tuple[str, str], tuple[int, str]] = {
 # Per-scenario competitor exclusions for the bar charts (per-scenario
 # views). The matrix still shows the override label; the bar chart
 # omits the bar entirely so the visual comparison stays honest.
+#
+# pl-lyfx has no get_emails-list or get_email-by-id tool — it would
+# show as ERROR/missing on those bar charts; cleaner to omit.
 BAR_CHART_EXCLUDE: dict[str, set[str]] = {
     "search_body": {"bastianzim"},
+    "get_emails": {"pl-lyfx"},
+    "get_email": {"pl-lyfx"},
 }
 
 SCENARIO_SHORT = {
@@ -293,9 +300,7 @@ def generate_overview_chart(
         z_values.append(row_z)
         annotations.append(row_a)
 
-    y_labels = [
-        COMPETITOR_LABELS.get(c, c) for c in reversed(competitors)
-    ]
+    y_labels = [COMPETITOR_LABELS.get(c, c) for c in reversed(competitors)]
     x_labels = [SCENARIO_SHORT[s] for s in scenarios]
 
     # Custom colorscale: 0=green, 0.5=red, 1=gray

--- a/benchmarks/competitors.py
+++ b/benchmarks/competitors.py
@@ -122,52 +122,7 @@ _register(
     )
 )
 
-# 3. kiki830621/che-apple-mail-mcp (Swift)
-_register(
-    Competitor(
-        name="kiki830621/che-apple-mail-mcp",
-        key="che-apple-mail",
-        command=[
-            f"{CACHE_DIR}/che-apple-mail-mcp/.build/release/CheAppleMailMCP",
-        ],
-        tool_mapping={
-            "list_accounts": ToolCall("list_accounts"),
-            "get_emails": ToolCall("list_emails", {"limit": 50}),
-            "search_subject": ToolCall(
-                "search_emails", {"query": SEARCH_QUERY}
-            ),
-        },
-    )
-)
-
-# 4. supermemoryai/apple-mcp (dhravya, archived Jan 2026)
-_register(
-    Competitor(
-        name="dhravya/apple-mcp",
-        key="dhravya",
-        command=["npx", "apple-mcp@latest"],
-        tool_mapping={
-            "list_accounts": ToolCall(
-                "mail",
-                {"operation": "accounts"},
-            ),
-            "get_emails": ToolCall(
-                "mail",
-                {"operation": "unread"},
-            ),
-            "search_subject": ToolCall(
-                "mail",
-                {
-                    "operation": "search",
-                    "searchTerm": SEARCH_QUERY,
-                },
-            ),
-        },
-        notes="Archived Jan 2026, historical baseline",
-    )
-)
-
-# 5. s-morgan-jeffries/apple-mail-mcp (Python, FastMCP)
+# 3. s-morgan-jeffries/apple-mail-mcp (Python, FastMCP)
 _register(
     Competitor(
         name="s-morgan-jeffries/apple-mail-mcp",
@@ -198,35 +153,7 @@ _register(
     )
 )
 
-# 6. attilagyorffy/apple-mail-mcp (Go, single binary)
-_register(
-    Competitor(
-        name="attilagyorffy/apple-mail-mcp",
-        key="attilagyorffy",
-        command=[
-            f"{CACHE_DIR}/attilagyorffy-apple-mail-mcp/bin/apple-mail-mcp",
-        ],
-        tool_mapping={
-            "get_emails": ToolCall(
-                "search_messages",
-                {
-                    "account": BENCHMARK_ACCOUNT,
-                    "limit": 50,
-                },
-            ),
-            "search_subject": ToolCall(
-                "search_messages",
-                {
-                    "account": BENCHMARK_ACCOUNT,
-                    "subject_contains": SEARCH_QUERY,
-                },
-            ),
-        },
-        notes="Go binary, no list_accounts or body search",
-    )
-)
-
-# 7. like-a-freedom/rusty_apple_mail_mcp (Rust, reads Envelope Index)
+# 4. like-a-freedom/rusty_apple_mail_mcp (Rust, reads Envelope Index)
 _register(
     Competitor(
         name="rusty_apple_mail_mcp",
@@ -255,7 +182,7 @@ _register(
     )
 )
 
-# 8. sweetrb/apple-mail-mcp (TypeScript, npm, AppleScript)
+# 5. sweetrb/apple-mail-mcp (TypeScript, npm, AppleScript)
 _register(
     Competitor(
         name="sweetrb/apple-mail-mcp",
@@ -286,7 +213,7 @@ _register(
     )
 )
 
-# 9. BastianZim/apple-mail-mcp (Python, no AppleScript, SQLite + .emlx)
+# 6. BastianZim/apple-mail-mcp (Python, no AppleScript, SQLite + .emlx)
 _register(
     Competitor(
         name="BastianZim/apple-mail-mcp",
@@ -320,6 +247,59 @@ _register(
             "Reads Envelope Index SQLite + .emlx directly, no AppleScript. "
             "No FTS5 — body search live-scans up to 5000 .emlx files. "
             "Closest head-to-head for the indexing thesis."
+        ),
+    )
+)
+
+# 7. pl-lyfx/apple-mail-mcp (Python single-file, Envelope Index direct)
+_register(
+    Competitor(
+        name="pl-lyfx/apple-mail-mcp",
+        key="pl-lyfx",
+        command=[
+            "python3",
+            f"{CACHE_DIR}/pl-lyfx-apple-mail-mcp/apple_mail_mcp.py",
+        ],
+        cwd=f"{CACHE_DIR}/pl-lyfx-apple-mail-mcp",
+        tool_mapping={
+            "list_accounts": ToolCall("mail_list_accounts"),
+            "search_subject": ToolCall(
+                "mail_search_by_subject", {"query": SEARCH_QUERY}
+            ),
+            "search_body": ToolCall("mail_search", {"query": SEARCH_QUERY}),
+        },
+        notes=(
+            "Single-file Python, reads Envelope Index SQLite directly. "
+            "No get_emails-list or get_email-by-id surface. "
+            "Script hardcodes MAIL_DIR / EMAIL / MAIL_VERSION constants — "
+            "edit top of apple_mail_mcp.py before benchmarking."
+        ),
+    )
+)
+
+# 8. titouancreach/apple-mail-mcp (Haskell, AppleScript-backed)
+_register(
+    Competitor(
+        name="titouancreach/apple-mail-mcp",
+        key="titouancreach",
+        command=[
+            f"{CACHE_DIR}/titouancreach-bin/apple-mail-mcp",
+        ],
+        tool_mapping={
+            "list_accounts": ToolCall("mail", {"operation": "accounts"}),
+            "get_emails": ToolCall(
+                "mail", {"operation": "latest", "limit": 50}
+            ),
+            "search_subject": ToolCall(
+                "mail",
+                {"operation": "search", "searchTerm": SEARCH_QUERY},
+            ),
+        },
+        notes=(
+            "Haskell, single 'mail' tool with operation params. "
+            "AppleScript-backed under the hood. "
+            "Pre-compiled to a native binary via `cabal install` for "
+            "fair cold-start comparison with Rust/Go entrants."
         ),
     )
 )

--- a/benchmarks/setup.sh
+++ b/benchmarks/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Setup script for apple-mail-mcp competitive benchmarks.
-# Installs all competitor MCP servers into ~/.cache/apple-mail-mcp-bench/.
+# Installs all 8 competitor MCP servers into ~/.cache/apple-mail-mcp-bench/.
 #
 # Usage: bash benchmarks/setup.sh
 
@@ -59,31 +59,7 @@ install_patrickfreyer() {
 }
 install_or_skip "patrickfreyer/apple-mail-mcp" install_patrickfreyer
 
-# ─── 3. kiki830621/che-apple-mail-mcp (Swift) ────────────────
-install_che_apple_mail() {
-    local dir="$CACHE_DIR/che-apple-mail-mcp"
-    if [ -d "$dir" ]; then
-        cd "$dir" && git pull --quiet
-    else
-        git clone --quiet --depth 1 \
-            https://github.com/kiki830621/che-apple-mail-mcp.git "$dir"
-    fi
-    cd "$dir"
-    swift build -c release 2>/dev/null
-}
-install_or_skip "kiki830621/che-apple-mail-mcp" install_che_apple_mail
-
-# ─── 4. supermemoryai/apple-mcp (dhravya, archived) ──────────
-install_dhravya() {
-    if ! command -v npx &>/dev/null; then
-        warn "npx not found — skipping dhravya"
-        return 1
-    fi
-    ok "dhravya/apple-mcp (will use npx at runtime)"
-}
-install_or_skip "supermemoryai/apple-mcp" install_dhravya
-
-# ─── 5. s-morgan-jeffries/apple-mail-mcp (Python) ────────────
+# ─── 3. s-morgan-jeffries/apple-mail-mcp (Python) ────────────
 install_smorgan() {
     local dir="$CACHE_DIR/smorgan-apple-mail-mcp"
     if [ -d "$dir" ]; then
@@ -98,25 +74,7 @@ install_smorgan() {
 }
 install_or_skip "s-morgan-jeffries/apple-mail-mcp" install_smorgan
 
-# ─── 6. attilagyorffy/apple-mail-mcp (Go) ────────────────────
-install_attilagyorffy() {
-    if ! command -v go &>/dev/null; then
-        warn "go not found — skipping attilagyorffy"
-        return 1
-    fi
-    local dir="$CACHE_DIR/attilagyorffy-apple-mail-mcp"
-    if [ -d "$dir" ]; then
-        cd "$dir" && git pull --quiet
-    else
-        git clone --quiet --depth 1 \
-            https://github.com/attilagyorffy/apple-mail-mcp.git "$dir"
-    fi
-    cd "$dir"
-    go build -o bin/apple-mail-mcp ./cmd/apple-mail-mcp 2>/dev/null
-}
-install_or_skip "attilagyorffy/apple-mail-mcp" install_attilagyorffy
-
-# ─── 7. like-a-freedom/rusty_apple_mail_mcp (Rust) ──────────
+# ─── 4. like-a-freedom/rusty_apple_mail_mcp (Rust) ──────────
 install_rusty() {
     if ! command -v cargo &>/dev/null; then
         warn "cargo not found — skipping rusty_apple_mail_mcp"
@@ -134,7 +92,7 @@ install_rusty() {
 }
 install_or_skip "rusty_apple_mail_mcp" install_rusty
 
-# ─── 8. sweetrb/apple-mail-mcp (TypeScript, npm) ─────────────
+# ─── 5. sweetrb/apple-mail-mcp (TypeScript, npm) ─────────────
 install_sweetrb() {
     if ! command -v npm &>/dev/null; then
         warn "npm not found — skipping sweetrb"
@@ -153,7 +111,7 @@ install_sweetrb() {
 }
 install_or_skip "sweetrb/apple-mail-mcp" install_sweetrb
 
-# ─── 9. BastianZim/apple-mail-mcp (Python, SQLite + .emlx) ───
+# ─── 6. BastianZim/apple-mail-mcp (Python, SQLite + .emlx) ───
 install_bastianzim() {
     local dir="$CACHE_DIR/bastianzim-apple-mail-mcp"
     if [ -d "$dir" ]; then
@@ -167,6 +125,45 @@ install_bastianzim() {
     .venv/bin/pip install -q -e . 2>/dev/null
 }
 install_or_skip "BastianZim/apple-mail-mcp" install_bastianzim
+
+# ─── 7. pl-lyfx/apple-mail-mcp (Python single-file, Envelope Index) ──
+install_pl_lyfx() {
+    local dir="$CACHE_DIR/pl-lyfx-apple-mail-mcp"
+    if [ -d "$dir" ]; then
+        cd "$dir" && git pull --quiet
+    else
+        git clone --quiet --depth 1 \
+            https://github.com/pl-lyfx/apple-mail-mcp.git "$dir"
+    fi
+    chmod +x "$dir/apple_mail_mcp.py"
+    warn "pl-lyfx: edit MAIL_DIR / EMAIL / MAIL_VERSION constants at the top of $dir/apple_mail_mcp.py before running benchmarks (no env-var fallback upstream yet)"
+}
+install_or_skip "pl-lyfx/apple-mail-mcp" install_pl_lyfx
+
+# ─── 8. titouancreach/apple-mail-mcp (Haskell, pre-compiled binary) ──
+install_titouancreach() {
+    if ! command -v cabal &>/dev/null; then
+        warn "cabal not found — install via ghcup: https://www.haskell.org/ghcup/"
+        return 1
+    fi
+    local dir="$CACHE_DIR/titouancreach-apple-mail-mcp"
+    if [ -d "$dir" ]; then
+        cd "$dir" && git pull --quiet
+    else
+        git clone --quiet --depth 1 \
+            https://github.com/titouancreach/apple-mail-mcp.git "$dir"
+    fi
+    cd "$dir"
+    # Pre-compile to a binary at $CACHE_DIR/titouancreach-bin/apple-mail-mcp
+    # so cold-start parity with Rust/Go entrants is fair (no cabal
+    # resolution cost on every spawn).
+    mkdir -p "$CACHE_DIR/titouancreach-bin"
+    cabal install --overwrite-policy=always \
+        --installdir="$CACHE_DIR/titouancreach-bin" \
+        --install-method=copy \
+        apple-mail-mcp.hs 2>&1 | tail -3
+}
+install_or_skip "titouancreach/apple-mail-mcp" install_titouancreach
 
 # ─── Summary ─────────────────────────────────────────────────
 echo ""

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Competitive benchmarks comparing Apple Mail MCP against 8 other Apple Mail MCP servers — inspired by [uv's BENCHMARKS.md](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md).
+Competitive benchmarks comparing Apple Mail MCP against 7 other Apple Mail MCP servers — inspired by [uv's BENCHMARKS.md](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md).
 
 All benchmarks are run at the **MCP protocol level**: we spawn each server as a subprocess, connect as a JSON-RPC client over stdio, and time real tool calls. This measures what an AI assistant actually experiences.
 
@@ -12,11 +12,13 @@ But "completes the operation" isn't the same as "covers the full mailbox." Basti
 
 ![Capability Matrix](benchmark_overview.png)
 
+> **Chart refresh pending.** The charts on this page were generated 2026-05-07 against the prior competitor slate. The current slate (Competitors table below) adds `pl-lyfx` and `titouancreach`, and drops `dhravya` (archived), `attilagyorffy` (stale), and `kiki830621` (uncompilable). A refreshed sweep will appear in the next release.
+
 ### What This Means
 
-- **Full-coverage body search is exclusive to Apple Mail MCP.** BastianZim has a body parameter but caps the scan at 5000 messages — see the "5K cap" cells in the matrix above. Every other competitor doesn't support body search at all.
-- **Apple's Envelope Index is the secret sauce when you don't need body search.** BastianZim and the Rust server both read it directly, which is why their `list_accounts`, `get_emails`, and subject-search numbers are sub-10ms — they're querying an index Apple already maintained for you.
-- **AppleScript-based servers struggle at this scale.** patrickfreyer, attilagyorffy, smorgan, and dhravya either timeout, hit AppleScript syntax errors on this macOS version, or simply don't implement the operation.
+- **Full-coverage body search is exclusive to Apple Mail MCP.** BastianZim has a body parameter but caps the scan at 5000 messages — see the "5K cap" cells in the matrix above. Every other competitor either doesn't support body search at all or scans only a partial set.
+- **Apple's Envelope Index is the secret sauce when you don't need body search.** BastianZim, rusty, and pl-lyfx all read it directly, which is why their `list_accounts` and subject-search numbers cluster at the top — they're querying an index Apple already maintained.
+- **AppleScript-based servers struggle at this scale.** patrickfreyer, sweetrb, titouancreach, and smorgan all wrap `osascript` for live Mail.app queries — fine at small scale, slow or unreliable on 72K-message mailboxes.
 - **Single email fetch is a near-tie at the top.** Our disk-first `.emlx` reader hits ~3ms; BastianZim's hits ~1ms via direct envelope-index lookup; Rust hits ~4ms.
 
 ## Test Environment
@@ -27,7 +29,7 @@ But "completes the operation" isn't the same as "covers the full mailbox." Basti
 | **Chip** | Apple M4 Max |
 | **Mailbox size** | ~72,000 messages across multiple accounts |
 | **Python** | 3.12.0 |
-| **Date** | 2026-05-07 |
+| **Date** | 2026-05-07 (last chart sweep — refresh pending) |
 
 ## Competitors
 
@@ -36,13 +38,26 @@ But "completes the operation" isn't the same as "covers the full mailbox." Basti
 | 1 | **[imdinu/apple-mail-mcp](https://github.com/imdinu/apple-mail-mcp)** (ours) | Python | Disk-first `.emlx` + batch JXA + FTS5 over the full mailbox |
 | 2 | **[BastianZim/apple-mail-mcp](https://github.com/BastianZim/apple-mail-mcp)** | Python | Reads Apple's Envelope Index directly; live `.emlx` body scan **capped at 5000 most recent messages** |
 | 3 | **[rusty_apple_mail_mcp](https://github.com/like-a-freedom/rusty_apple_mail_mcp)** | Rust | Reads Apple's Envelope Index directly; no body search |
-| 4 | **[patrickfreyer/apple-mail-mcp](https://github.com/patrickfreyer/apple-mail-mcp)** | Python | AppleScript-based, 26+ tools |
-| 5 | **[sweetrb/apple-mail-mcp](https://github.com/sweetrb/apple-mail-mcp)** | TypeScript | AppleScript-based, 40+ tools, mail-merge & templates |
-| 6 | **[attilagyorffy/apple-mail-mcp](https://github.com/attilagyorffy/apple-mail-mcp)** | Go | AppleScript-based |
-| 7 | **[s-morgan-jeffries/apple-mail-mcp](https://github.com/s-morgan-jeffries/apple-mail-mcp)** | Python | AppleScript-based |
-| 8 | **[dhravya/apple-mcp](https://github.com/supermemoryai/apple-mcp)** | TypeScript | Multi-app (archived Jan 2026) |
+| 4 | **[pl-lyfx/apple-mail-mcp](https://github.com/pl-lyfx/apple-mail-mcp)** | Python | Single-file, reads Apple's Envelope Index directly; no `get_emails`-list or `get_email`-by-id surface |
+| 5 | **[patrickfreyer/apple-mail-mcp](https://github.com/patrickfreyer/apple-mail-mcp)** | Python | AppleScript-based, 26+ tools |
+| 6 | **[sweetrb/apple-mail-mcp](https://github.com/sweetrb/apple-mail-mcp)** | TypeScript | AppleScript-based, 40+ tools, mail-merge & templates |
+| 7 | **[titouancreach/apple-mail-mcp](https://github.com/titouancreach/apple-mail-mcp)** | Haskell | Single-file cabal script, AppleScript-backed; only Haskell entry in the ecosystem |
+| 8 | **[s-morgan-jeffries/apple-mail-mcp](https://github.com/s-morgan-jeffries/apple-mail-mcp)** | Python | AppleScript-based |
 
-> **Note**: `kiki830621/che-apple-mail-mcp` (Swift) is currently uncompilable on Xcode 14 SDKs (`PackageDescription` link error) and is omitted from this run.
+## Also noted
+
+These projects exist in the ecosystem but aren't benchmarked above. Listed for completeness — not for direct comparison.
+
+**Demoted from prior runs**
+
+- **[supermemoryai/apple-mcp](https://github.com/supermemoryai/apple-mcp)** (dhravya) — Archived January 2026; historical baseline only.
+- **[attilagyorffy/apple-mail-mcp](https://github.com/attilagyorffy/apple-mail-mcp)** — Go, 0⭐, last push March 2026; supplanted by other Go entrants and fails AppleScript probes on macOS 26+.
+- **[kiki830621/che-apple-mail-mcp](https://github.com/kiki830621/che-apple-mail-mcp)** — Swift, currently uncompilable on Xcode 14 SDKs (`PackageDescription` link error).
+- **[fatbobman/mail-mcp-bridge](https://github.com/fatbobman/mail-mcp-bridge)** — Python, "bridge" model that expects a user-supplied Message-ID copied from inside Mail.app; no list or search surface, not a benchmark peer.
+
+**New entrants (Feb–May 2026, not yet benchmarked)**
+
+`Clarus-Moof/AppleMailMCP`, `ANemcov/apple-mailapp-mcp`, `maximbilan/apple-mail-mcp-go`, `dastrobu/apple-mail-mcp`, `jayvee6/apple-mail-mcp`, `Agentic-Assets/apple-mail-mcp` — all 0–1⭐ single-author exploratory projects without distinct architectural claims. Watch this space.
 
 ## Detailed Results
 
@@ -50,31 +65,31 @@ Each scenario: **5 warmup runs + 10 measured runs**. We report the **median** wi
 
 ### Cold Start
 
-Time from spawning the server process to receiving an MCP `initialize` response. Native binaries (Rust, Go) and lean Python servers (BastianZim) have a natural advantage here — no FastMCP overhead, no FTS5 schema check.
+Time from spawning the server process to receiving an MCP `initialize` response. Native binaries (Rust, Go, the pre-compiled Haskell entrant) and lean Python servers (BastianZim, pl-lyfx) have a natural advantage here — no FastMCP overhead, no FTS5 schema check.
 
 ![Cold Start](benchmark_cold_start.png)
 
 ### List Accounts
 
-Servers reading Apple's Envelope Index directly (BastianZim, rusty) finish in ~1ms — they're issuing a `SELECT DISTINCT` against an index Apple already maintained. AppleScript- and JXA-based paths pay the `osascript` round-trip, which dominates the time.
+Servers reading Apple's Envelope Index directly (BastianZim, rusty, pl-lyfx) finish in ~1ms — they're issuing a `SELECT DISTINCT` against an index Apple already maintained. AppleScript- and JXA-based paths pay the `osascript` round-trip, which dominates the time.
 
 ![List Accounts](benchmark_list_accounts.png)
 
 ### Fetch 50 Emails
 
-Three servers can't complete this on a 72K mailbox: smorgan and attilagyorffy throw AppleScript errors, patrickfreyer exceeds the 10-second probe cutoff. Our JXA-based `batchFetch` is correct and reliable but ~500x slower than direct SQLite reads.
+Several AppleScript-based servers can't complete this on a 72K mailbox: smorgan throws AppleScript errors, patrickfreyer exceeds the 10-second probe cutoff. pl-lyfx has no list-emails surface and is omitted from this chart. Our JXA-based `batchFetch` is correct and reliable but ~500x slower than direct SQLite reads.
 
 ![Fetch Emails](benchmark_get_emails.png)
 
 ### Fetch Single Email
 
-Our disk-first strategy reads `.emlx` files directly — no JXA needed. Performance is within ~2x of BastianZim's envelope-index-only metadata lookup.
+Our disk-first strategy reads `.emlx` files directly — no JXA needed. Performance is within ~2x of BastianZim's envelope-index-only metadata lookup. pl-lyfx has no `get_email`-by-id surface and is omitted from this chart.
 
 ![Fetch Single Email](benchmark_get_email.png)
 
 ### Search by Subject
 
-FTS5 column filtering gives us sub-10ms subject search, competitive with the Rust server's direct SQLite queries.
+FTS5 column filtering gives us sub-10ms subject search, competitive with the Rust server's direct SQLite queries and pl-lyfx's direct Envelope-Index reads.
 
 ![Search Subject](benchmark_search_subject.png)
 
@@ -103,8 +118,9 @@ FTS5 column filtering gives us sub-10ms subject search, competitive with the Rus
 2. **FTS5 requires one-time indexing.** Body and subject search require `apple-mail-mcp index` first. Cold start time does not include indexing.
 3. **Not all servers support all operations.** The capability matrix above shows which operations each server supports.
 4. **Capped competitors are flagged, not run.** BastianZim's body search is fast but covers only the 5000 most recent messages on this mailbox — we mark its `search_body` cell as "5K cap" in the matrix and omit it from the body-search bar chart entirely. Including the bar would imply apples-to-apples comparison.
-5. **macOS and Mail.app versions matter.** Performance varies across OS versions; some AppleScript errors are version-specific (e.g., attilagyorffy's `date -j` flag incompatibility on macOS 26).
-6. **Archived projects benchmarked as-is.** dhravya/apple-mcp is archived with known bugs.
+5. **macOS and Mail.app versions matter.** Performance varies across OS versions; some AppleScript errors are version-specific.
+6. **pl-lyfx requires manual configuration.** The upstream script hardcodes `MAIL_DIR`, `EMAIL`, and `MAIL_VERSION` constants at the top of `apple_mail_mcp.py` — edit before running the benchmarks.
+7. **titouancreach requires GHC + cabal.** The Haskell toolchain (~2 GB via [ghcup](https://www.haskell.org/ghcup/)) is needed to build the binary. The benchmark pre-compiles via `cabal install` for cold-start parity with Rust/Go entrants.
 
 ## Reproduction
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The only Apple Mail MCP server with **full-coverage FTS5 body search**. Reliable
 
 ## Why Apple Mail MCP?
 
-Tested against [8 other Apple Mail MCP servers](benchmarks.md) on a real ~72K-message mailbox:
+Tested against [7 other Apple Mail MCP servers](benchmarks.md) on a real ~72K-message mailbox:
 
 - **Only server with full-coverage body search.** Most competitors don't support body search at all; the one that does (BastianZim) caps at the 5000 most recent messages — silent miss on older mail. Our FTS5 covers the entire mailbox.
 - **~3ms** single email fetch via disk-first `.emlx` reading.


### PR DESCRIPTION
## Summary

Refactors the competitive benchmark slate to drop stale projects and add two new first-class entries. Ships the structural change now; chart PNG refresh is a follow-up after the next sweep.

**Demotions (to a new "Also noted" section in `docs/benchmarks.md`):**
- `dhravya` (supermemoryai/apple-mcp) — archived January 2026
- `attilagyorffy` — 0⭐ Go, supplanted by newer Go entrants, fails AppleScript probes on macOS 26+
- `kiki830621` (che-apple-mail) — Swift, uncompilable on Xcode 14 SDKs (already silently excluded)
- `fatbobman/mail-mcp-bridge` — bridge architecture, expects user-supplied Message-ID; no list/search surface, not a benchmark peer

**Additions (first-class, will be benchmarked on next sweep):**
- `pl-lyfx/apple-mail-mcp` — single-file Python, reads Envelope Index directly. Natural cluster-mate for bastianzim and rusty. Upstream script hardcodes config constants; setup.sh emits a warn line.
- `titouancreach/apple-mail-mcp` — Haskell, single-file cabal script, AppleScript-backed. Pre-compiled to a native binary at install time for cold-start parity with Rust/Go entrants.

**Other refresh:**
- Reordered `COMPETITOR_ORDER` in `benchmarks/charts.py` so Envelope-Index-direct readers cluster at the top.
- Added `BAR_CHART_EXCLUDE` entries for pl-lyfx on `get_emails` and `get_email` (no comparable surface).
- Surfaced six 0–1⭐ Feb–May 2026 newcomers (`Clarus-Moof`, `ANemcov`, `maximbilan`, `dastrobu`, `jayvee6`, `Agentic-Assets`) in "Also noted" for ecosystem-breadth context.
- Net count: 9 configured competitors → 8 (us + 7 others). All four "N other Apple Mail MCP servers" references across `README.md`, `docs/index.md`, `docs/benchmarks.md`, and `CLAUDE.md` now consistently say "7 other".

**What's *not* in this PR:** the chart PNGs at the repo root. They reflect the prior slate (2026-05-07 run); `docs/benchmarks.md` carries an explicit "Chart refresh pending" caveat above the capability matrix. A follow-up commit after the next sweep will replace the PNGs and drop the caveat.

## Relationship to #91

This PR branches from `main` (0.3.3) and is independent of the v0.4.0 work in #91. No file-level overlap with #91 — they can merge in either order.

## Test plan

- [x] `uv run pytest` — 364/364 pass (no test changes; benchmarks/ isn't part of the test suite)
- [x] `uv run ruff check benchmarks/competitors.py benchmarks/charts.py` — clean
- [x] `uv run ruff format --check benchmarks/competitors.py benchmarks/charts.py` — clean
- [x] `bash -n benchmarks/setup.sh` — syntax OK
- [x] Smoke test: `competitors.py` has exactly the 8 expected keys, `charts.py` LABELS and ORDER match the COMPETITORS dict
- [x] Count grep: all four `"other Apple Mail MCP servers"` references say "7 other"
- [ ] **Manual (follow-up commit):** `bash benchmarks/setup.sh` on a macOS bench machine to verify each install function. Requires GHC/cabal for titouancreach (~2 GB toolchain via ghcup). pl-lyfx requires editing top-of-file constants before running.
- [ ] **Manual (follow-up commit):** `uv run --group bench python -m benchmarks.run` for the full sweep, then `python -m benchmarks.charts` to regenerate PNGs at repo root. Drop the "Chart refresh pending" caveat in `docs/benchmarks.md` once charts are refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)