### PR TITLE
Fix get_emails() returning [] for Gmail-backed accounts (label-based mailbox membership)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`get_emails()` no longer returns `[]` for Gmail-backed accounts**: the Envelope Index fast path matched mailbox membership only via the `messages.mailbox` FK and a raw-name `LIKE` on the mailbox URL. Gmail accounts keep every message in `[Gmail]/All Mail`, with INBOX (and other label-backed mailbox) membership recorded only in the `labels` table, so INBOX queries matched zero rows and returned a silent empty list; mailbox names containing spaces or brackets ("Sent Mail", "All Mail") also never matched because URLs store percent-encoded paths. The fast path now resolves the requested mailbox to ROWIDs first (percent-decoding URLs, matching the full path or its bare final segment, case-insensitively) and treats a message as a member via either `messages.mailbox` or a `labels` row. An unknown mailbox raises the new `MailboxNotFoundError` and falls back to JXA instead of masquerading as an empty mailbox. Two adjacent silent-scoping holes are closed in the same path: an unresolvable account name now falls back to JXA instead of silently querying every account, and an unspecified account scopes to the first account (matching the documented default and the JXA path) instead of all of them. (#102)
+
 ## [0.4.1] - 2026-06-12
 
 ### Fixed

--- a/src/apple_mail_mcp/index/envelope_direct.py
+++ b/src/apple_mail_mcp/index/envelope_direct.py
@@ -28,8 +28,19 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import unquote
 
 logger = logging.getLogger(__name__)
+
+
+class MailboxNotFoundError(LookupError):
+    """The requested mailbox has no match in the Envelope Index.
+
+    Raised instead of returning an empty result so the caller can
+    distinguish "mailbox unknown to the index" from "mailbox is
+    empty" and fall back to JXA, which resolves mailbox names
+    authoritatively.
+    """
 
 
 @dataclass(frozen=True)
@@ -68,7 +79,9 @@ def _parse_mailbox_url(url: str) -> tuple[str, str]:
 
     Mail.app URLs look like `ews://<UUID>/<mailbox-name>` or
     `imap://<UUID>/<mailbox-name>`. The scheme varies; the shape
-    after `://` is consistent.
+    after `://` is consistent. The path is stored percent-encoded
+    (`Sent%20Mail`, `%5BGmail%5D/All%20Mail`) and is returned
+    fully decoded.
 
     Returns ("", "") if the URL doesn't parse.
     """
@@ -77,7 +90,7 @@ def _parse_mailbox_url(url: str) -> tuple[str, str]:
     _, _, rest = url.partition("://")
     parts = rest.split("/", 1)
     if len(parts) == 2:
-        return (parts[0], parts[1].replace("%20", " "))
+        return (parts[0], unquote(parts[1]))
     return (parts[0], "")
 
 
@@ -115,6 +128,49 @@ def list_account_uuids(envelope_path: Path) -> list[str]:
         conn.close()
 
 
+def _has_labels_table(conn: sqlite3.Connection) -> bool:
+    """Whether this Envelope Index has the Gmail `labels` table."""
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'labels'"
+    ).fetchone()
+    return row is not None
+
+
+def _resolve_mailbox_rowids(
+    conn: sqlite3.Connection,
+    account_uuid: str | None,
+    mailbox_name: str,
+) -> list[int]:
+    """Find ROWIDs of mailboxes whose decoded name matches.
+
+    Mailbox URLs store percent-encoded paths, so matching a raw
+    name against the URL misses any mailbox whose name contains a
+    space or bracket. Decode each URL and match the full path or
+    its final segment: Gmail mailboxes live under a `[Gmail]/`
+    prefix but are displayed and addressed by their bare name
+    (`Sent Mail`, not `[Gmail]/Sent Mail`). Matching is
+    case-insensitive because the configured default mailbox is
+    "Inbox" while IMAP stores "INBOX".
+    """
+    if account_uuid:
+        cur = conn.execute(
+            "SELECT ROWID, url FROM mailboxes WHERE url LIKE ?",
+            (f"%://{account_uuid}/%",),
+        )
+    else:
+        cur = conn.execute(
+            "SELECT ROWID, url FROM mailboxes WHERE url IS NOT NULL"
+        )
+    want = mailbox_name.casefold()
+    rowids: list[int] = []
+    for rowid, url in cur:
+        _, path = _parse_mailbox_url(url)
+        decoded = path.casefold()
+        if decoded == want or decoded.rsplit("/", 1)[-1] == want:
+            rowids.append(rowid)
+    return rowids
+
+
 def fetch_recent_messages(
     envelope_path: Path,
     *,
@@ -129,12 +185,19 @@ def fetch_recent_messages(
     columns; honors read/flagged/date filters as WHERE clauses on
     the direct integer columns of `messages`.
 
+    Mailbox membership is checked both via the `messages.mailbox`
+    FK and via the Gmail `labels` table: Gmail-backed accounts
+    keep every message in `[Gmail]/All Mail`, and membership in
+    INBOX (and other label-backed mailboxes) exists only as
+    `labels` rows.
+
     Args:
         envelope_path: Path to Apple's Envelope Index SQLite.
         account_uuid: Account UUID to restrict to, or None for
             all accounts.
-        mailbox_name: Mailbox name to restrict to (matched as a
-            suffix of the mailbox URL), or None for all mailboxes
+        mailbox_name: Mailbox name to restrict to (matched
+            case-insensitively against the percent-decoded URL
+            path or its final segment), or None for all mailboxes
             within the account.
         filter_kind: One of "all", "unread", "flagged", "today",
             "last_7_days", "this_week".
@@ -146,17 +209,58 @@ def fetch_recent_messages(
     Raises:
         sqlite3.OperationalError: On schema mismatch. Caller
             should fall back to JXA.
+        MailboxNotFoundError: When `mailbox_name` matches no
+            mailbox in the index. Caller should fall back to
+            JXA rather than report an empty mailbox.
     """
+    conn = sqlite3.connect(f"file:{envelope_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        return _fetch_recent_messages(
+            conn,
+            account_uuid=account_uuid,
+            mailbox_name=mailbox_name,
+            filter_kind=filter_kind,
+            limit=limit,
+        )
+    finally:
+        conn.close()
+
+
+def _fetch_recent_messages(
+    conn: sqlite3.Connection,
+    *,
+    account_uuid: str | None,
+    mailbox_name: str | None,
+    filter_kind: str,
+    limit: int,
+) -> list[EnvelopeMessageRow]:
+    """Body of fetch_recent_messages, on an open connection."""
     where_clauses: list[str] = ["m.deleted = 0"]
     params: list[object] = []
 
-    if account_uuid:
-        if mailbox_name:
-            where_clauses.append("mb.url LIKE ?")
-            params.append(f"%://{account_uuid}/{mailbox_name}%")
+    if mailbox_name:
+        mailbox_ids = _resolve_mailbox_rowids(conn, account_uuid, mailbox_name)
+        if not mailbox_ids:
+            scope = f" in account {account_uuid}" if account_uuid else ""
+            raise MailboxNotFoundError(
+                f"no mailbox named {mailbox_name!r}{scope} in Envelope Index"
+            )
+        placeholders = ", ".join("?" for _ in mailbox_ids)
+        if _has_labels_table(conn):
+            where_clauses.append(
+                f"(m.mailbox IN ({placeholders}) OR m.ROWID IN "
+                f"(SELECT message_id FROM labels "
+                f"WHERE mailbox_id IN ({placeholders})))"
+            )
+            params.extend(mailbox_ids)
+            params.extend(mailbox_ids)
         else:
-            where_clauses.append("mb.url LIKE ?")
-            params.append(f"%://{account_uuid}/%")
+            where_clauses.append(f"m.mailbox IN ({placeholders})")
+            params.extend(mailbox_ids)
+    elif account_uuid:
+        where_clauses.append("mb.url LIKE ?")
+        params.append(f"%://{account_uuid}/%")
 
     if filter_kind == "unread":
         where_clauses.append("m.read = 0")
@@ -200,26 +304,21 @@ def fetch_recent_messages(
     """
     params.append(int(limit))
 
-    conn = sqlite3.connect(f"file:{envelope_path}?mode=ro", uri=True)
-    conn.row_factory = sqlite3.Row
-    try:
-        cur = conn.execute(sql, params)
-        rows: list[EnvelopeMessageRow] = []
-        for r in cur:
-            uuid, mailbox_n = _parse_mailbox_url(r["mailbox_url"] or "")
-            rows.append(
-                EnvelopeMessageRow(
-                    message_id=int(r["message_id"]) if r["message_id"] else 0,
-                    subject=r["subject"] or "",
-                    sender=r["sender"] or "",
-                    date_received=_unix_ts_to_iso(r["date_received"]),
-                    mailbox_url=r["mailbox_url"] or "",
-                    account_uuid=uuid,
-                    mailbox_name=mailbox_n,
-                    read=bool(r["read_flag"]),
-                    flagged=bool(r["flagged_flag"]),
-                )
+    cur = conn.execute(sql, params)
+    rows: list[EnvelopeMessageRow] = []
+    for r in cur:
+        uuid, mailbox_n = _parse_mailbox_url(r["mailbox_url"] or "")
+        rows.append(
+            EnvelopeMessageRow(
+                message_id=int(r["message_id"]) if r["message_id"] else 0,
+                subject=r["subject"] or "",
+                sender=r["sender"] or "",
+                date_received=_unix_ts_to_iso(r["date_received"]),
+                mailbox_url=r["mailbox_url"] or "",
+                account_uuid=uuid,
+                mailbox_name=mailbox_n,
+                read=bool(r["read_flag"]),
+                flagged=bool(r["flagged_flag"]),
             )
-        return rows
-    finally:
-        conn.close()
+        )
+    return rows

--- a/src/apple_mail_mcp/server.py
+++ b/src/apple_mail_mcp/server.py
@@ -339,6 +339,7 @@ async def get_emails(
     try:
         from .index.disk import find_mail_directory
         from .index.envelope_direct import (
+            MailboxNotFoundError,
             envelope_index_path,
             fetch_recent_messages,
         )
@@ -350,32 +351,50 @@ async def get_emails(
             # the cache via JXA on first hit; subsequent calls are
             # in-process.
             await _get_account_map().ensure_loaded()
-            account_uuid = (
-                _get_account_map().name_to_uuid(target_account)
-                if target_account
-                else None
-            )
+            account_uuid: str | None = None
+            if target_account:
+                account_uuid = _get_account_map().name_to_uuid(target_account)
+            else:
+                # No account requested: scope to the first account,
+                # matching the documented behavior and the JXA path
+                # (which would otherwise see a different result set).
+                cached = _get_account_map().get_cached_accounts()
+                if cached:
+                    account_uuid = cached[0]["id"]
 
-            rows = await asyncio.to_thread(
-                fetch_recent_messages,
-                env_path,
-                account_uuid=account_uuid,
-                mailbox_name=target_mailbox,
-                filter_kind=filter,
-                limit=limit,
-            )
-            return [
-                EmailSummary(
-                    id=r.message_id,
-                    subject=r.subject,
-                    sender=r.sender,
-                    date_received=r.date_received,
-                    read=r.read,
-                    flagged=r.flagged,
+            if target_account and account_uuid is None:
+                # Unknown account name. Fall through to JXA, which
+                # reports it properly, rather than silently widening
+                # the query to every account.
+                logger.debug(
+                    "Account %r not in AccountMap; falling back to JXA",
+                    target_account,
                 )
-                for r in rows
-            ]
-    except (FileNotFoundError, sqlite3.OperationalError) as exc:
+            else:
+                rows = await asyncio.to_thread(
+                    fetch_recent_messages,
+                    env_path,
+                    account_uuid=account_uuid,
+                    mailbox_name=target_mailbox,
+                    filter_kind=filter,
+                    limit=limit,
+                )
+                return [
+                    EmailSummary(
+                        id=r.message_id,
+                        subject=r.subject,
+                        sender=r.sender,
+                        date_received=r.date_received,
+                        read=r.read,
+                        flagged=r.flagged,
+                    )
+                    for r in rows
+                ]
+    except (
+        FileNotFoundError,
+        sqlite3.OperationalError,
+        MailboxNotFoundError,
+    ) as exc:
         logger.debug(
             "Envelope Index fast path unavailable (%s); falling back to JXA",
             exc,

--- a/tests/test_envelope_direct.py
+++ b/tests/test_envelope_direct.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from apple_mail_mcp.index.envelope_direct import (
+    MailboxNotFoundError,
     _parse_mailbox_url,
     _unix_ts_to_iso,
     envelope_index_path,
@@ -63,6 +64,10 @@ class TestParseMailboxUrl:
     def test_url_with_percent_encoded_space(self):
         _, mb = _parse_mailbox_url("ews://UUID/Deleted%20Items")
         assert mb == "Deleted Items"
+
+    def test_url_with_percent_encoded_brackets(self):
+        _, mb = _parse_mailbox_url("imap://UUID/%5BGmail%5D/All%20Mail")
+        assert mb == "[Gmail]/All Mail"
 
     def test_uuid_only(self):
         assert _parse_mailbox_url("ews://UUID-789/") == ("UUID-789", "")
@@ -246,3 +251,180 @@ class TestFetchRecentMessages:
         for r in rows:
             assert r.account_uuid == "ACCOUNT-A"
             assert r.mailbox_name == "Inbox"
+
+
+# ─── Gmail label-backed mailbox membership ───────────────────
+
+
+@pytest.fixture
+def gmail_envelope(tmp_path: Path) -> Path:
+    """Envelope Index shaped like a Gmail-backed account.
+
+    Mail.app keeps every Gmail message in `[Gmail]/All Mail`;
+    membership in INBOX and other label-backed mailboxes is
+    recorded only in the `labels` table, and mailbox URLs are
+    stored percent-encoded.
+    """
+    db = tmp_path / "Envelope Index"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE subjects (ROWID INTEGER PRIMARY KEY, subject TEXT);
+        CREATE TABLE addresses (
+            ROWID INTEGER PRIMARY KEY, address TEXT, comment TEXT
+        );
+        CREATE TABLE mailboxes (ROWID INTEGER PRIMARY KEY, url TEXT);
+        CREATE TABLE messages (
+            ROWID INTEGER PRIMARY KEY,
+            message_id INTEGER,
+            sender INTEGER,
+            subject INTEGER,
+            date_received INTEGER,
+            mailbox INTEGER,
+            read INTEGER DEFAULT 0,
+            flagged INTEGER DEFAULT 0,
+            deleted INTEGER DEFAULT 0
+        );
+        CREATE TABLE labels (
+            message_id INTEGER,
+            mailbox_id INTEGER,
+            PRIMARY KEY (message_id, mailbox_id)
+        ) WITHOUT ROWID;
+
+        INSERT INTO subjects VALUES
+          (1, 'Invoice'), (2, 'Newsletter'), (3, 'Receipt');
+        INSERT INTO addresses VALUES
+          (1, 'vendor@example.com', ''),
+          (2, 'news@example.com', '');
+        INSERT INTO mailboxes VALUES
+          (1, 'imap://ACCOUNT-G/%5BGmail%5D/All%20Mail'),
+          (2, 'imap://ACCOUNT-G/INBOX'),
+          (3, 'imap://ACCOUNT-G/%5BGmail%5D/Sent%20Mail'),
+          (4, 'imap://ACCOUNT-H/INBOX');
+
+        -- Every ACCOUNT-G message lives in All Mail (mailbox 1);
+        -- INBOX / Sent Mail membership exists only as label rows.
+        -- ACCOUNT-H is a plain IMAP account with direct membership,
+        -- and message 4 also carries a redundant label row to prove
+        -- the two membership paths don't double-count.
+        INSERT INTO messages VALUES
+          (1, 100, 1, 1, 800000000, 1, 0, 0, 0),
+          (2, 200, 2, 2, 800001000, 1, 1, 0, 0),
+          (3, 300, 1, 3, 800002000, 1, 1, 0, 0),
+          (4, 400, 2, 1, 800003000, 4, 0, 0, 0);
+        INSERT INTO labels VALUES (1, 2), (2, 2), (3, 3), (4, 4);
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+class TestGmailLabelMembership:
+    def test_inbox_membership_via_labels(self, gmail_envelope):
+        # The INBOX mailbox row has no direct messages.mailbox
+        # members; messages 1 and 2 are INBOX only via labels.
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-G",
+            mailbox_name="INBOX",
+            filter_kind="all",
+            limit=10,
+        )
+        assert {r.message_id for r in rows} == {1, 2}
+
+    def test_percent_encoded_mailbox_by_display_name(self, gmail_envelope):
+        # "Sent Mail" is stored as %5BGmail%5D/Sent%20Mail and is
+        # addressed by its bare display name.
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-G",
+            mailbox_name="Sent Mail",
+            filter_kind="all",
+            limit=10,
+        )
+        assert {r.message_id for r in rows} == {3}
+
+    def test_full_decoded_path_also_matches(self, gmail_envelope):
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-G",
+            mailbox_name="[Gmail]/Sent Mail",
+            filter_kind="all",
+            limit=10,
+        )
+        assert {r.message_id for r in rows} == {3}
+
+    def test_mailbox_match_is_case_insensitive(self, gmail_envelope):
+        # The configured default mailbox is "Inbox"; IMAP stores
+        # "INBOX".
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-G",
+            mailbox_name="Inbox",
+            filter_kind="all",
+            limit=10,
+        )
+        assert {r.message_id for r in rows} == {1, 2}
+
+    def test_unknown_mailbox_raises_not_empty(self, gmail_envelope):
+        # An unknown mailbox must be distinguishable from an empty
+        # one so the caller can fall back to JXA.
+        with pytest.raises(MailboxNotFoundError):
+            fetch_recent_messages(
+                gmail_envelope,
+                account_uuid="ACCOUNT-G",
+                mailbox_name="No Such Mailbox",
+                filter_kind="all",
+                limit=10,
+            )
+
+    def test_no_cross_account_leakage(self, gmail_envelope):
+        # ACCOUNT-H's INBOX message must not appear in ACCOUNT-G's.
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-G",
+            mailbox_name="INBOX",
+            filter_kind="all",
+            limit=10,
+        )
+        assert 4 not in {r.message_id for r in rows}
+
+    def test_direct_and_label_membership_not_double_counted(
+        self, gmail_envelope
+    ):
+        # Message 4 is in ACCOUNT-H's INBOX both directly and via a
+        # label row; it must appear exactly once.
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-H",
+            mailbox_name="INBOX",
+            filter_kind="all",
+            limit=10,
+        )
+        assert [r.message_id for r in rows] == [4]
+
+    def test_unread_filter_composes_with_labels(self, gmail_envelope):
+        # Message 1 is unread, message 2 is read; both are
+        # INBOX-labeled.
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid="ACCOUNT-G",
+            mailbox_name="INBOX",
+            filter_kind="unread",
+            limit=10,
+        )
+        assert {r.message_id for r in rows} == {1}
+
+    def test_no_account_scopes_by_mailbox_across_accounts(self, gmail_envelope):
+        # With no account, a named mailbox must still scope results
+        # (all accounts' INBOXes), never the whole message table.
+        rows = fetch_recent_messages(
+            gmail_envelope,
+            account_uuid=None,
+            mailbox_name="INBOX",
+            filter_kind="all",
+            limit=10,
+        )
+        # Message 3 is Sent Mail only and must be excluded.
+        assert {r.message_id for r in rows} == {1, 2, 4}


### PR DESCRIPTION
Fixes #102.

## Problem

The Strategy-0 Envelope Index fast path checks mailbox membership only via the `messages.mailbox` FK, matched with a raw-name `LIKE` against the mailbox URL. That breaks two ways for Gmail-backed accounts:

1. Mail.app stores every Gmail message in `[Gmail]/All Mail`; membership in INBOX (and any other label-backed mailbox) is recorded only in the `labels (message_id, mailbox_id)` table. The INBOX mailbox row has zero direct members, so `get_emails(account, "INBOX")` returned a silent `[]` and, since an empty result is not an exception, never fell back to JXA.
2. Mailbox URLs store percent-encoded paths (`Sent%20Mail`, `%5BGmail%5D/All%20Mail`), so any mailbox name containing a space or bracket never matched the raw-name pattern either.

## Fix

- `fetch_recent_messages` now resolves the requested mailbox to ROWIDs first: each URL is percent-decoded (`urllib.parse.unquote`, replacing the previous `%20`-only handling in `_parse_mailbox_url`) and matched against the full decoded path or its bare final segment, case-insensitively ("Sent Mail" addresses `[Gmail]/Sent Mail`; the default "Inbox" matches IMAP's "INBOX"). This also retires the unescaped-LIKE prefix-over-match ("INBOX" no longer matches "INBOX-Archive").
- Membership is `messages.mailbox IN (...) OR ROWID IN (SELECT message_id FROM labels WHERE mailbox_id IN (...))`. Schemas without a `labels` table keep the FK-only check.
- An unknown mailbox raises the new `MailboxNotFoundError`, which `server.py` treats like the existing fast-path errors and falls through to JXA, so "mailbox unknown to the index" is no longer indistinguishable from "mailbox is empty".
- Two adjacent silent-scoping holes in `server.py` are closed in the same path: an account name that fails AccountMap resolution falls back to JXA instead of silently dropping both filters and querying every account, and an unspecified account scopes to the first account (matching the documented default and the JXA path) instead of all accounts.

## Testing

- New `gmail_envelope` fixture modeled on a real Envelope Index (All Mail holds the messages; INBOX/Sent Mail membership exists only as `labels` rows; URLs percent-encoded) plus 9 tests covering label membership, encoded names, full-path and case-insensitive matching, unknown-mailbox raising, cross-account isolation, no double-counting for dual membership, and filter composition. 7 of 9 fail against the previous code.
- Full suite passes (463 tests).
- Verified against a live Gmail-backed mailbox on macOS 14 / Mail V10: INBOX returns 104/104 messages (was 0), unread count matches the Mail.app badge exactly, "Sent Mail" and "Spam" resolve correctly, and an unknown mailbox falls back to JXA.