### PR TITLE
fix: keep full path for nested mailboxes in FTS index (#105) [needs design input]

### DIFF
--- a/src/apple_mail_mcp/index/disk.py
+++ b/src/apple_mail_mcp/index/disk.py
@@ -1234,10 +1234,23 @@ def _infer_account_mailbox(emlx_path: Path, mail_dir: Path) -> tuple[str, str]:
     """
     Infer account and mailbox from .emlx file path.
 
-    Handles nested mailboxes like Work/Projects/Q1.mbox by scanning
-    forward to find the first .mbox-ending path component.
+    A mailbox hierarchy nests one .mbox per level, so the name spans every
+    component up to the Data/ payload directory:
 
-    Path structure: V10/account-uuid/[nested/]mailbox.mbox/Data/.../id.emlx
+        V10/<uuid>/Ablage.mbox/Nebenkosten.mbox/<store-uuid>/Data/.../1.emlx
+            -> ("<uuid>", "Ablage/Nebenkosten")
+
+    IMAP accounts that nest below an INBOX. prefix have the same shape
+    (INBOX.mbox/Junk.mbox/...) and yield "INBOX/Junk". Taking only the first
+    .mbox collapses every child onto its outermost parent.
+
+    Components are accumulated until Data/ so that a hierarchy expressed as
+    plain directories (Work/Projects.mbox) keeps working, while the .mbox
+    suffix is stripped per level and the per-mailbox store UUID that may sit
+    between the leaf .mbox and Data/ is left out.
+
+    Path structure:
+        V10/account-uuid/[nested/]mailbox.mbox/[store-uuid/]Data/.../id.emlx
     """
     try:
         relative = emlx_path.relative_to(mail_dir)
@@ -1246,15 +1259,22 @@ def _infer_account_mailbox(emlx_path: Path, mail_dir: Path) -> tuple[str, str]:
         # First part is account UUID
         account = parts[0] if parts else "Unknown"
 
-        # Find the part ending with .mbox — may span multiple components
-        # e.g. parts = ("UUID", "Work", "Projects", "Q1.mbox", "Data", ...)
-        mailbox = "Unknown"
-        for i, part in enumerate(parts[1:], start=1):
-            if part.endswith(".mbox"):
-                # Join components from parts[1] to parts[i], strip .mbox
-                components = (*parts[1:i], part[:-5])
-                mailbox = "/".join(components)
+        components: list[str] = []
+        saw_mbox = False
+        for part in parts[1:]:
+            if part == "Data":
                 break
+            if part.endswith(".mbox"):
+                components.append(part[:-5])
+                saw_mbox = True
+            elif saw_mbox:
+                # Store UUID between the leaf .mbox and Data/ — not a level.
+                break
+            else:
+                # Plain parent directory above the first .mbox.
+                components.append(part)
+
+        mailbox = "/".join(components) if saw_mbox else "Unknown"
 
         return (account, mailbox)
     except ValueError:

--- a/src/apple_mail_mcp/index/watcher.py
+++ b/src/apple_mail_mcp/index/watcher.py
@@ -39,8 +39,13 @@ logger = logging.getLogger(__name__)
 
 # Regex to extract account/mailbox from path
 # ~/Library/Mail/V10/[AccountUUID]/[Mailbox].mbox/.../*.emlx
+# The mailbox group is greedy so it runs to the LAST .mbox: a nested mailbox
+# is one .mbox per level (Ablage.mbox/Nebenkosten.mbox), and a non-greedy
+# group would stop at the first level and collapse every child onto its
+# outermost parent. Anchoring the tail on Data/ keeps the optional
+# per-mailbox store UUID out of the captured name.
 PATH_PATTERN = re.compile(
-    r"/V\d+/([^/]+)/(.+?)\.mbox/.*?/(\d+)(?:\.partial)?\.emlx$"
+    r"/V\d+/([^/]+)/(.+)\.mbox/(?:[^/]+/)?Data/.*?/(\d+)(?:\.partial)?\.emlx$"
 )
 
 # Constants for safety limits
@@ -244,7 +249,12 @@ class IndexWatcher:
 
         # Use UUID as account name (more reliable than trying to map)
         account_name = account_uuid
-        mailbox_name = mailbox_dir
+        # The regex strips only the trailing .mbox; nested levels keep theirs.
+        # "Ablage.mbox/Nebenkosten" -> "Ablage/Nebenkosten"
+        mailbox_name = "/".join(
+            part[:-5] if part.endswith(".mbox") else part
+            for part in mailbox_dir.split("/")
+        )
 
         return account_name, mailbox_name, message_id
 

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -1558,6 +1558,66 @@ class TestInferNestedMailbox:
         assert account == "acc"
         assert mailbox == "Unknown"
 
+    def test_infer_mbox_per_level(self, tmp_path: Path):
+        """Each hierarchy level is its own .mbox on disk (#105)."""
+        mail_dir = tmp_path / "V10"
+        emlx = (
+            mail_dir
+            / "acc"
+            / "Ablage.mbox"
+            / "Nebenkosten.mbox"
+            / "E93C0B8E-7306-46F1-9BF5-ADD723DD3190"
+            / "Data"
+            / "2"
+            / "Messages"
+            / "262370.emlx"
+        )
+        emlx.parent.mkdir(parents=True)
+        emlx.touch()
+
+        account, mailbox = _infer_account_mailbox(emlx, mail_dir)
+        assert account == "acc"
+        assert mailbox == "Ablage/Nebenkosten"
+
+    def test_infer_mbox_per_level_several(self, tmp_path: Path):
+        mail_dir = tmp_path / "V10"
+        emlx = (
+            mail_dir
+            / "acc"
+            / "Ablage.mbox"
+            / "IHK.mbox"
+            / "IHK Stuttgart.mbox"
+            / "Data"
+            / "1"
+            / "Messages"
+            / "5.emlx"
+        )
+        emlx.parent.mkdir(parents=True)
+        emlx.touch()
+
+        _account, mailbox = _infer_account_mailbox(emlx, mail_dir)
+        assert mailbox == "Ablage/IHK/IHK Stuttgart"
+
+    def test_infer_imap_inbox_prefix(self, tmp_path: Path):
+        """IMAP INBOX. prefix nests siblings below INBOX.mbox."""
+        mail_dir = tmp_path / "V10"
+        emlx = (
+            mail_dir
+            / "acc"
+            / "INBOX.mbox"
+            / "Junk.mbox"
+            / "store-uuid"
+            / "Data"
+            / "9"
+            / "Messages"
+            / "239389.emlx"
+        )
+        emlx.parent.mkdir(parents=True)
+        emlx.touch()
+
+        _account, mailbox = _infer_account_mailbox(emlx, mail_dir)
+        assert mailbox == "INBOX/Junk"
+
 
 class TestExtractLinksFromMessage:
     """_extract_links_from_message parses HTML <a> tags."""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -194,23 +194,34 @@ class TestPathParsing:
         assert m.group(1) == "9C1979D8-5686-4309-9EE8-1FB7F450F1FE"
         assert m.group(2) == "Inbox"
 
-    def test_handles_nested_mbox(self):
-        """Gmail-style [Gmail].mbox/All Mail.mbox paths.
+    def test_handles_nested_mbox(self, tmp_path: Path):
+        """Gmail-style [Gmail].mbox/All Mail.mbox paths keep the leaf.
 
-        The regex captures up to the first .mbox boundary,
-        so nested mailboxes like [Gmail].mbox/All Mail.mbox
-        capture '[Gmail]' as the mailbox name — this matches
-        how the index stores Gmail mailboxes.
+        This previously asserted '[Gmail]', describing the non-greedy
+        regex's first-boundary behaviour rather than a Gmail decision:
+        the nested-mailbox change (#48) predates it and never mentions
+        Gmail. #102/#103 later established, verified against a live
+        account, that Gmail keeps messages in '[Gmail]/All Mail' — and
+        envelope_direct._resolve_mailbox_rowids matches a stored path by
+        its full value *or* its last segment, so the leaf name is what
+        makes 'All Mail' addressable. Collapsing to '[Gmail]' throws it
+        away and merges every Gmail mailbox into one.
         """
-        from apple_mail_mcp.index.watcher import PATH_PATTERN
+        db_path = tmp_path / "w.db"
+        conn = create_connection(str(db_path))
+        conn.executescript(get_schema_sql())
+        conn.execute("INSERT INTO schema_version (version) VALUES (?)", (4,))
+        conn.commit()
+        conn.close()
 
-        m = PATH_PATTERN.search(
-            "/Users/x/Library/Mail/V11/acc"
-            "/[Gmail].mbox/All Mail.mbox"
-            "/Data/1/Messages/100.partial.emlx"
+        result = IndexWatcher(db_path)._parse_path(
+            Path(
+                "/Users/x/Library/Mail/V11/acc"
+                "/[Gmail].mbox/All Mail.mbox"
+                "/Data/1/Messages/100.partial.emlx"
+            )
         )
-        assert m is not None
-        assert m.group(2) == "[Gmail]"
+        assert result == ("acc", "[Gmail]/All Mail", 100)
 
     def test_handles_v11_directory(self):
         """Dynamic version detection: V11 paths should match."""
@@ -258,6 +269,48 @@ class TestPendingLimits:
             )
 
         assert len(watcher._pending_adds) == MAX_PENDING_CHANGES
+
+
+class TestMboxPerLevelPaths:
+    """Each level of a real mailbox hierarchy is its own .mbox (#105)."""
+
+    def _parse(self, tmp_path: Path, raw: str) -> tuple[str, str, int] | None:
+        db_path = tmp_path / "w.db"
+        conn = create_connection(str(db_path))
+        conn.executescript(get_schema_sql())
+        conn.execute("INSERT INTO schema_version (version) VALUES (?)", (4,))
+        conn.commit()
+        conn.close()
+        return IndexWatcher(db_path)._parse_path(Path(raw))
+
+    def test_child_keeps_parent_and_leaf(self, tmp_path: Path):
+        # A store UUID sits between the leaf .mbox and Data/.
+        assert self._parse(
+            tmp_path,
+            "/Users/x/Library/Mail/V10/acc/Ablage.mbox/Nebenkosten.mbox"
+            "/E93C0B8E-7306-46F1-9BF5-ADD723DD3190/Data/2/Messages/262370.emlx",
+        ) == ("acc", "Ablage/Nebenkosten", 262370)
+
+    def test_several_levels(self, tmp_path: Path):
+        assert self._parse(
+            tmp_path,
+            "/Users/x/Library/Mail/V10/acc/Ablage.mbox/IHK.mbox"
+            "/IHK Stuttgart.mbox/Data/1/Messages/5.emlx",
+        ) == ("acc", "Ablage/IHK/IHK Stuttgart", 5)
+
+    def test_imap_inbox_prefix(self, tmp_path: Path):
+        # IMAP servers with an INBOX. prefix nest everything below INBOX.mbox.
+        assert self._parse(
+            tmp_path,
+            "/Users/x/Library/Mail/V10/acc/INBOX.mbox/Junk.mbox"
+            "/store-uuid/Data/9/Messages/239389.emlx",
+        ) == ("acc", "INBOX/Junk", 239389)
+
+    def test_flat_mailbox_unchanged(self, tmp_path: Path):
+        assert self._parse(
+            tmp_path,
+            "/Users/x/Library/Mail/V10/acc/INBOX.mbox/Data/1/Messages/123.emlx",
+        ) == ("acc", "INBOX", 123)
 
 
 class TestNestedMailboxRegex:


### PR DESCRIPTION
Addresses #105. **Draft on purpose** — the parser fix is correct and tested, but it is a breaking change with consumers I have not addressed, and how far to take it is your call, not mine. Details below.

## The bug

Every level of a mailbox hierarchy is its own `.mbox` directory on disk:

```
V10/<account-uuid>/Ablage.mbox/Nebenkosten.mbox/<store-uuid>/Data/2/6/2/Messages/262370.emlx
```

`_infer_account_mailbox` (`disk.py`) and `PATH_PATTERN` (`watcher.py`) both stop at the **first** `.mbox`, so every child collapses onto its outermost parent — indexed as `Ablage`, not `Ablage/Nebenkosten`.

Measured on one real account: `Ablage` holds **28,275 messages** from ~20 distinct mailboxes, and **no** `mailbox` value in the entire index (~57k rows) contains a slash. The failure is silent — `search(mailbox="Nebenkosten")` returns **0 hits, not an error**, on a folder holding 74 messages.

### Why this matters beyond nesting: it merges Spam into your inbox results

On a live Gmail-backed account, running the fixed parser against the real store:

```
[Gmail].mbox/Alle Nachrichten.mbox  -> today: "[Gmail]"   fixed: "[Gmail]/Alle Nachrichten"
[Gmail].mbox/Papierkorb.mbox        -> today: "[Gmail]"   fixed: "[Gmail]/Papierkorb"
[Gmail].mbox/Spam.mbox              -> today: "[Gmail]"   fixed: "[Gmail]/Spam"
```

All 38 indexed messages on that account sit under the single value `[Gmail]` — All Mail, Trash and **Spam** share one mailbox identity, even though `schema.py:177` makes `mailbox` part of `UNIQUE(account, mailbox, message_id)`.

## ⚠️ Breaking change

After a reindex, `search(mailbox="[Gmail]")` returns **0** where it returns 38 today. `search.py:160` compares `LOWER(mailbox) = LOWER(?)` exactly, and with an index present there is no JXA fallback (`server.py:1214`) — the empty result goes straight out.

Note that last-segment matching (as in `_resolve_mailbox_rowids`) does **not** paper over this: the leaf of `[Gmail]/Spam` is `Spam`, not `[Gmail]`. Preserving the old call would need prefix/subtree matching. I mention it because it looks like the obvious fix and isn't.

## Consumers this PR does *not* fix

Storing the full path is right, but several places assume the collapsed name and I deliberately stopped rather than guess your intent:

- **`search.py`** — include *and* `exclude_mailboxes` both compare exactly; also affects FTS, highlight, count, attachments (`search.py:313`, `:435`, `:538`).
- **`manager.py:673`, `:866`** — location/path/attachment lookups match exactly; stale parent-name hints break links and attachments hard.
- **`server.py:803` → `jxa/mail_core.js:39`** — full paths get handed to a JXA resolver that doesn't understand slash hierarchies.
- **Exclusions** — `disk.py:1069` only checks the outermost parent; the watcher has no mailbox excludes at all (`watcher.py:304`).
- **Upgrade path** — existing indexes keep the old values until a rebuild; nothing detects or forces that.

A sensible resolution is probably: exact full-path first, then an *unambiguous* leaf fallback (envelope's resolver unions ambiguous leaves — worth not copying blindly). But that's a design call across the whole API surface, so I'd rather hear your preference than push a direction.

## About the Gmail test

`test_handles_nested_mbox` asserted `[Gmail]`, its docstring calling that intentional ("this matches how the index stores Gmail mailboxes"). I changed it, so here's the reasoning:

- The nested-mailbox change (`3904cee`, #48, 2026-03-06) **predates the test by a month**, never mentions Gmail, and switched `([^/]+)` → `(.+?)` purely to allow slashes before a single trailing `.mbox`.
- The test (`c35674e`, 2026-04-05) shipped **no production change** and no rationale — it characterised existing regex behaviour.
- That phrase appears **nowhere else in the repo**.
- #102/#103 later established, verified against a live account, that Gmail stores messages in **`[Gmail]/All Mail`** — the full path.
- The live data above shows the collapse merges Spam and Trash into one identity, which is hard to read as intent.

If it *was* deliberate for reasons outside the repo, say so and I'll rework around it.

## State

- 4 files, parser only. `500 passed`; `ruff check`/`format --check` clean on touched files.
- 7 regression cases (mbox-per-level with and without store UUID, several levels, IMAP `INBOX.` prefix) in the existing test classes.
- Verified against a real store: 159 nested mailboxes resolve correctly, both parsers agreeing.
- **Not covered:** nested-search tests, exclude tests, the consumers listed above, index upgrade.

Happy to take this further in whatever direction you prefer — or to split it, if you'd rather land the parser and handle the API surface separately.
